### PR TITLE
make QuantumV2 support requested nic ordering

### DIFF
--- a/nova/network/quantumv2/api.py
+++ b/nova/network/quantumv2/api.py
@@ -84,6 +84,11 @@ class API(base.Base):
             search_opts['id'] = net_ids
         nets += quantum.list_networks(**search_opts).get('networks', [])
 
+        _ensure_requested_network_ordering(
+            lambda x: x['id'],
+            nets,
+            net_ids)
+
         return nets
 
     def allocate_for_instance(self, context, instance, **kwargs):
@@ -345,6 +350,13 @@ class API(base.Base):
         if not networks:
             networks = self._get_available_networks(context,
                                                     instance['project_id'])
+        else:
+            # ensure ports are in preferred network order
+            _ensure_requested_network_ordering(
+                lambda x: x['network_id'],
+                ports,
+                [n['id'] for n in networks])
+
         nw_info = network_model.NetworkInfo()
         for port in ports:
             network_name = None
@@ -458,3 +470,9 @@ class API(base.Base):
     def create_public_dns_domain(self, context, domain, project=None):
         """Create a private DNS domain with optional nova project."""
         raise NotImplementedError()
+
+
+def _ensure_requested_network_ordering(accessor, unordered, preferred):
+    """Sort a list with respect to the preferred network ordering."""
+    if preferred:
+        unordered.sort(key=lambda i: preferred.index(accessor(i)))

--- a/nova/tests/network/test_quantumv2.py
+++ b/nova/tests/network/test_quantumv2.py
@@ -329,35 +329,37 @@ class TestQuantumv2(test.TestCase):
                     self.moxed_client.show_port(port_id).AndReturn(
                         {'port': {'id': 'my_portid1',
                          'network_id': 'my_netid1'}})
-                    req_net_ids.append('my_netid1')
                     ports['my_netid1'] = self.port_data1[0]
                     id = 'my_netid1'
                 else:
                     fixed_ips[id] = fixed_ip
                 req_net_ids.append(id)
+            expected_network_order = req_net_ids
+        else:
+            expected_network_order = [n['id'] for n in nets]
         search_ids = [net['id'] for net in nets if net['id'] in req_net_ids]
 
         mox_list_network_params = dict(tenant_id=self.instance['project_id'],
                                        shared=False)
         if search_ids:
-            mox_list_network_params['id'] = search_ids
+            mox_list_network_params['id'] = mox.SameElementsAs(search_ids)
         self.moxed_client.list_networks(
             **mox_list_network_params).AndReturn({'networks': nets})
 
         mox_list_network_params = dict(shared=True)
         if search_ids:
-            mox_list_network_params['id'] = search_ids
+            mox_list_network_params['id'] = mox.SameElementsAs(search_ids)
         self.moxed_client.list_networks(
             **mox_list_network_params).AndReturn({'networks': []})
 
-        for network in nets:
+        for net_id in expected_network_order:
             port_req_body = {
                 'port': {
                     'device_id': self.instance['uuid'],
                     'device_owner': 'compute:nova',
                 },
             }
-            port = ports.get(network['id'], None)
+            port = ports.get(net_id, None)
             if port:
                 port_id = port['id']
                 self.moxed_client.update_port(port_id,
@@ -365,10 +367,10 @@ class TestQuantumv2(test.TestCase):
                                               ).AndReturn(
                                                   {'port': port})
             else:
-                fixed_ip = fixed_ips.get(network['id'])
+                fixed_ip = fixed_ips.get(net_id)
                 if fixed_ip:
                     port_req_body['port']['fixed_ip'] = fixed_ip
-                port_req_body['port']['network_id'] = network['id']
+                port_req_body['port']['network_id'] = net_id
                 port_req_body['port']['admin_state_up'] = True
                 port_req_body['port']['tenant_id'] = \
                     self.instance['project_id']
@@ -388,8 +390,9 @@ class TestQuantumv2(test.TestCase):
 
     def test_allocate_for_instance_with_requested_networks(self):
         # specify only first and last network
-        requested_networks = [(net['id'], None, None)
-                              for net in (self.nets3[0], self.nets3[-1])]
+        requested_networks = [
+            (net['id'], None, None)
+            for net in (self.nets3[1], self.nets3[0], self.nets3[2])]
         self._allocate_for_instance(net_idx=3,
                                     requested_networks=requested_networks)
 
@@ -621,3 +624,292 @@ class TestQuantumv2(test.TestCase):
         # specify only first and last network
         req_ids = [net['id'] for net in (self.nets3[0], self.nets3[-1])]
         self._get_available_networks(prv_nets, pub_nets, req_ids)
+
+    def test_get_floating_ip_pools(self):
+        api = quantumapi.API()
+        search_opts = {'router:external': True}
+        self.moxed_client.list_networks(**search_opts).\
+            AndReturn({'networks': [self.fip_pool, self.fip_pool_nova]})
+        self.mox.ReplayAll()
+        pools = api.get_floating_ip_pools(self.context)
+        expected = [{'name': self.fip_pool['name']},
+                    {'name': self.fip_pool_nova['name']}]
+        self.assertEqual(expected, pools)
+
+    def _get_expected_fip_model(self, fip_data, idx=0):
+        expected = {'id': fip_data['id'],
+                    'address': fip_data['floating_ip_address'],
+                    'pool': self.fip_pool['name'],
+                    'project_id': fip_data['tenant_id'],
+                    'fixed_ip_id': fip_data['port_id'],
+                    'fixed_ip':
+                        {'address': fip_data['fixed_ip_address']},
+                    'instance': ({'uuid': self.port_data2[idx]['device_id']}
+                                 if fip_data['port_id']
+                                 else None)}
+        return expected
+
+    def _test_get_floating_ip(self, fip_data, idx=0, by_address=False):
+        api = quantumapi.API()
+        fip_id = fip_data['id']
+        net_id = fip_data['floating_network_id']
+        address = fip_data['floating_ip_address']
+        if by_address:
+            self.moxed_client.list_floatingips(floating_ip_address=address).\
+                AndReturn({'floatingips': [fip_data]})
+        else:
+            self.moxed_client.show_floatingip(fip_id).\
+                AndReturn({'floatingip': fip_data})
+        self.moxed_client.show_network(net_id).\
+            AndReturn({'network': self.fip_pool})
+        if fip_data['port_id']:
+            self.moxed_client.show_port(fip_data['port_id']).\
+                AndReturn({'port': self.port_data2[idx]})
+        self.mox.ReplayAll()
+
+        expected = self._get_expected_fip_model(fip_data, idx)
+
+        if by_address:
+            fip = api.get_floating_ip_by_address(self.context, address)
+        else:
+            fip = api.get_floating_ip(self.context, fip_id)
+        self.assertEqual(expected, fip)
+
+    def test_get_floating_ip_unassociated(self):
+        self._test_get_floating_ip(self.fip_unassociated, idx=0)
+
+    def test_get_floating_ip_associated(self):
+        self._test_get_floating_ip(self.fip_associated, idx=1)
+
+    def test_get_floating_ip_by_address(self):
+        self._test_get_floating_ip(self.fip_unassociated, idx=0,
+                                   by_address=True)
+
+    def test_get_floating_ip_by_address_associated(self):
+        self._test_get_floating_ip(self.fip_associated, idx=1,
+                                   by_address=True)
+
+    def test_get_floating_ip_by_address_not_found(self):
+        api = quantumapi.API()
+        address = self.fip_unassociated['floating_ip_address']
+        self.moxed_client.list_floatingips(floating_ip_address=address).\
+            AndReturn({'floatingips': []})
+        self.mox.ReplayAll()
+        self.assertRaises(exception.FloatingIpNotFoundForAddress,
+                          api.get_floating_ip_by_address,
+                          self.context, address)
+
+    def test_get_floating_ip_by_address_multiple_found(self):
+        api = quantumapi.API()
+        address = self.fip_unassociated['floating_ip_address']
+        self.moxed_client.list_floatingips(floating_ip_address=address).\
+            AndReturn({'floatingips': [self.fip_unassociated] * 2})
+        self.mox.ReplayAll()
+        self.assertRaises(exception.FloatingIpMultipleFoundForAddress,
+                          api.get_floating_ip_by_address,
+                          self.context, address)
+
+    def test_get_floating_ips_by_project(self):
+        api = quantumapi.API()
+        project_id = self.context.project_id
+        self.moxed_client.list_floatingips(tenant_id=project_id).\
+            AndReturn({'floatingips': [self.fip_unassociated,
+                                       self.fip_associated]})
+        search_opts = {'router:external': True}
+        self.moxed_client.list_networks(**search_opts).\
+            AndReturn({'networks': [self.fip_pool, self.fip_pool_nova]})
+        self.moxed_client.list_ports(tenant_id=project_id).\
+                AndReturn({'ports': self.port_data2})
+        self.mox.ReplayAll()
+
+        expected = [self._get_expected_fip_model(self.fip_unassociated),
+                    self._get_expected_fip_model(self.fip_associated, idx=1)]
+        fips = api.get_floating_ips_by_project(self.context)
+        self.assertEqual(expected, fips)
+
+    def _test_get_instance_id_by_floating_address(self, fip_data,
+                                                  associated=False):
+        api = quantumapi.API()
+        address = fip_data['floating_ip_address']
+        self.moxed_client.list_floatingips(floating_ip_address=address).\
+                AndReturn({'floatingips': [fip_data]})
+        if associated:
+            self.moxed_client.show_port(fip_data['port_id']).\
+                AndReturn({'port': self.port_data2[1]})
+        self.mox.ReplayAll()
+
+        if associated:
+            expected = self.port_data2[1]['device_id']
+        else:
+            expected = None
+        fip = api.get_instance_id_by_floating_address(self.context, address)
+        self.assertEqual(expected, fip)
+
+    def test_get_instance_id_by_floating_address(self):
+        self._test_get_instance_id_by_floating_address(self.fip_unassociated)
+
+    def test_get_instance_id_by_floating_address_associated(self):
+        self._test_get_instance_id_by_floating_address(self.fip_associated,
+                                                       associated=True)
+
+    def test_allocate_floating_ip(self):
+        api = quantumapi.API()
+        pool_name = self.fip_pool['name']
+        pool_id = self.fip_pool['id']
+        search_opts = {'router:external': True,
+                       'fields': 'id',
+                       'name': pool_name}
+        self.moxed_client.list_networks(**search_opts).\
+            AndReturn({'networks': [self.fip_pool]})
+        self.moxed_client.create_floatingip(
+            {'floatingip': {'floating_network_id': pool_id}}).\
+            AndReturn({'floatingip': self.fip_unassociated})
+        self.mox.ReplayAll()
+        fip = api.allocate_floating_ip(self.context, 'ext_net')
+        self.assertEqual(fip, self.fip_unassociated['floating_ip_address'])
+
+    def test_allocate_floating_ip_with_pool_id(self):
+        api = quantumapi.API()
+        pool_name = self.fip_pool['name']
+        pool_id = self.fip_pool['id']
+        search_opts = {'router:external': True,
+                       'fields': 'id',
+                       'id': pool_id}
+        self.moxed_client.list_networks(**search_opts).\
+            AndReturn({'networks': [self.fip_pool]})
+        self.moxed_client.create_floatingip(
+            {'floatingip': {'floating_network_id': pool_id}}).\
+            AndReturn({'floatingip': self.fip_unassociated})
+        self.mox.ReplayAll()
+        fip = api.allocate_floating_ip(self.context, pool_id)
+        self.assertEqual(fip, self.fip_unassociated['floating_ip_address'])
+
+    def test_allocate_floating_ip_with_default_pool(self):
+        api = quantumapi.API()
+        pool_name = self.fip_pool_nova['name']
+        pool_id = self.fip_pool_nova['id']
+        search_opts = {'router:external': True,
+                       'fields': 'id',
+                       'name': pool_name}
+        self.moxed_client.list_networks(**search_opts).\
+            AndReturn({'networks': [self.fip_pool_nova]})
+        self.moxed_client.create_floatingip(
+            {'floatingip': {'floating_network_id': pool_id}}).\
+            AndReturn({'floatingip': self.fip_unassociated})
+        self.mox.ReplayAll()
+        fip = api.allocate_floating_ip(self.context)
+        self.assertEqual(fip, self.fip_unassociated['floating_ip_address'])
+
+    def test_release_floating_ip(self):
+        api = quantumapi.API()
+        address = self.fip_unassociated['floating_ip_address']
+        fip_id = self.fip_unassociated['id']
+
+        self.moxed_client.list_floatingips(floating_ip_address=address).\
+            AndReturn({'floatingips': [self.fip_unassociated]})
+        self.moxed_client.delete_floatingip(fip_id)
+        self.mox.ReplayAll()
+        api.release_floating_ip(self.context, address)
+
+    def test_release_floating_ip_associated(self):
+        api = quantumapi.API()
+        address = self.fip_associated['floating_ip_address']
+        fip_id = self.fip_associated['id']
+
+        self.moxed_client.list_floatingips(floating_ip_address=address).\
+            AndReturn({'floatingips': [self.fip_associated]})
+        self.mox.ReplayAll()
+        self.assertRaises(exception.FloatingIpAssociated,
+                          api.release_floating_ip, self.context, address)
+
+    def _setup_mock_for_refresh_cache(self, api):
+        nw_info = self.mox.CreateMock(model.NetworkInfo)
+        nw_info.json()
+        self.mox.StubOutWithMock(api, '_get_instance_nw_info')
+        api._get_instance_nw_info(mox.IgnoreArg(), self.instance).\
+            AndReturn(nw_info)
+        self.mox.StubOutWithMock(api.db, 'instance_info_cache_update')
+        api.db.instance_info_cache_update(mox.IgnoreArg(),
+                                          self.instance['uuid'],
+                                          mox.IgnoreArg())
+
+    def test_associate_floating_ip(self):
+        api = quantumapi.API()
+        address = self.fip_associated['floating_ip_address']
+        fixed_address = self.fip_associated['fixed_ip_address']
+        fip_id = self.fip_associated['id']
+
+        search_opts = {'device_owner': 'compute:nova',
+                       'device_id': self.instance['uuid']}
+        self.moxed_client.list_ports(**search_opts).\
+            AndReturn({'ports': [self.port_data2[1]]})
+        self.moxed_client.list_floatingips(floating_ip_address=address).\
+            AndReturn({'floatingips': [self.fip_associated]})
+        self.moxed_client.update_floatingip(
+            fip_id, {'floatingip': {'port_id': self.fip_associated['port_id'],
+                                    'fixed_ip_address': fixed_address}})
+        self._setup_mock_for_refresh_cache(api)
+
+        self.mox.ReplayAll()
+        api.associate_floating_ip(self.context, self.instance,
+                                  address, fixed_address)
+
+    def test_associate_floating_ip_not_found_fixed_ip(self):
+        api = quantumapi.API()
+        address = self.fip_associated['floating_ip_address']
+        fixed_address = self.fip_associated['fixed_ip_address']
+        fip_id = self.fip_associated['id']
+
+        search_opts = {'device_owner': 'compute:nova',
+                       'device_id': self.instance['uuid']}
+        self.moxed_client.list_ports(**search_opts).\
+            AndReturn({'ports': [self.port_data2[0]]})
+
+        self.mox.ReplayAll()
+        self.assertRaises(exception.FixedIpNotFoundForAddress,
+                          api.associate_floating_ip, self.context,
+                          self.instance, address, fixed_address)
+
+    def test_disassociate_floating_ip(self):
+        api = quantumapi.API()
+        address = self.fip_associated['floating_ip_address']
+        fip_id = self.fip_associated['id']
+
+        self.moxed_client.list_floatingips(floating_ip_address=address).\
+            AndReturn({'floatingips': [self.fip_associated]})
+        self.moxed_client.update_floatingip(
+            fip_id, {'floatingip': {'port_id': None}})
+        self._setup_mock_for_refresh_cache(api)
+
+        self.mox.ReplayAll()
+        api.disassociate_floating_ip(self.context, self.instance, address)
+
+
+class TestQuantumv2ModuleMethods(test.TestCase):
+    def test_ensure_requested_network_ordering_no_preference(self):
+        l = [1, 2, 3]
+
+        quantumapi._ensure_requested_network_ordering(
+            lambda x: x,
+            l,
+            None)
+
+    def test_ensure_requested_network_ordering_no_preference(self):
+        l = [{'id': 3}, {'id': 1}, {'id': 2}]
+
+        quantumapi._ensure_requested_network_ordering(
+            lambda x: x['id'],
+            l,
+            None)
+
+        self.assertEqual(l, [{'id': 3}, {'id': 1}, {'id': 2}])
+
+    def test_ensure_requested_network_ordering_with_preference(self):
+        l = [{'id': 3}, {'id': 1}, {'id': 2}]
+
+        quantumapi._ensure_requested_network_ordering(
+            lambda x: x['id'],
+            l,
+            [1, 2, 3])
+
+        self.assertEqual(l, [{'id': 1}, {'id': 2}, {'id': 3}])


### PR DESCRIPTION
Bring in 3316e1fb9f2689dbc70b3cffbf38ea0ebf2f9f07 from upstream.

fixes bug 1064524

The QuantumV2 did not honor nic ordering, so nics were attached in
Quantum's db natural order.  This patch sorts the networks honor requested nic
ordering when Nova calls the V2Quantum API.  Unit tests have been updated to
confirm ordering is honored.

Change-Id: I44a6a4736c78e86e83b6e682e63f93a5b47652da
