### PR TITLE
Set is_public to False by default for volume backed snapshots

### DIFF
--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -1924,6 +1924,7 @@ class API(base.Base):
         :returns: the new image metadata
         """
         image_meta['name'] = name
+        image_meta['is_public'] = False
         properties = image_meta['properties']
         if instance['root_device_name']:
             properties['root_device_name'] = instance['root_device_name']

--- a/nova/tests/compute/test_compute_api.py
+++ b/nova/tests/compute/test_compute_api.py
@@ -1397,6 +1397,7 @@ class _ComputeAPIUnitTestMixIn(object):
             'name': 'test-snapshot',
             'properties': {'root_device_name': 'vda', 'mappings': 'DONTCARE'},
             'size': 0,
+            'is_public': False
         }
 
         def fake_get_instance_bdms(context, instance):


### PR DESCRIPTION
This update results in the same behavior that is already implemented
in _create_image where the meta_data for is_public is set to False.

Originally committed by Abel Lopez via puppet-coe-service-patch
and cherry picked from upstream here.  Abel's commit log:

---

commit 17a5e697b380b8051dc2967b2e6a32be83ebec35
Author: Abel Lopez abelopez@cisco.com
Date:   Mon Jul 14 10:11:57 2014 -0700

```
DE391 - Private snapshots by default

This addresses DE391 - Taken from Icehouse branch at
https://github.com/openstack/nova/blob/stable/icehouse/nova/compute/api.py#L
Snapshots should be Private, this line was overlooked in Havana for
Volume backed snapshots.

Change-Id: Iaba3b6441b56a4a93a79441732c9e4b433c05b26
```

---

Change-Id: Ie0720d5c847871527db7d9477ca6cb05abe7a1a5
Closes-Bug: #1255316
Implements: rally-user-story US4145
Implements: rally-task TA3473
Closes-rally-bug: DE391
Upstream-Review: https://review.openstack.org/#/c/112662/
