### PR TITLE
Always filter out multicast from reflection

### DIFF
--- a/nova/virt/libvirt/firewall.py
+++ b/nova/virt/libvirt/firewall.py
@@ -219,9 +219,8 @@ class NWFilterFirewall(base_firewall.FirewallDriver):
         filter_set = ['no-mac-spoofing',
                       'no-ip-spoofing',
                       'no-arp-spoofing']
-        if CONF.use_ipv6:
-            self._define_filter(self.nova_no_nd_reflection_filter)
-            filter_set.append('nova-no-nd-reflection')
+        self._define_filter(self.nova_no_nd_reflection_filter)
+        filter_set.append('nova-no-nd-reflection')
         self._define_filter(self._filter_container('nova-nodhcp', filter_set))
         filter_set.append('allow-dhcp-server')
         self._define_filter(self._filter_container('nova-base', filter_set))


### PR DESCRIPTION
Instances will try IPv6 neighbour discovery via multicast
even in an IPv4-only cloud and can throw errors
if they see inbound packets from their own MAC address

Closes-bug: #1229625
Closes-rally-bug: DE711

Change-Id: I3539e788fe07519d87ce7c3800c5d38b7bd99d3b
(cherry picked from commit 9c044d2c94812e18cf84927fbf719cd073fe6c4f)
