### PR TITLE
Havana ephemeral rbd

### DIFF
--- a/nova/api/ec2/cloud.py
+++ b/nova/api/ec2/cloud.py
@@ -30,6 +30,7 @@ from oslo.config import cfg
 from nova.api.ec2 import ec2utils
 from nova.api.ec2 import inst_state
 from nova.api.metadata import password
+from nova.api.openstack import extensions
 from nova.api import validator
 from nova import availability_zones
 from nova import block_device
@@ -84,6 +85,9 @@ CONF.import_opt('internal_service_availability_zone',
 LOG = logging.getLogger(__name__)
 
 QUOTAS = quota.QUOTAS
+
+security_group_authorizer = extensions.extension_authorizer('compute',
+                                                            'security_groups')
 
 
 def validate_ec2_id(val):
@@ -631,6 +635,8 @@ class CloudController(object):
         security_group = self.security_group_api.get(context, group_name,
                                                      group_id)
 
+        security_group_authorizer(context, security_group)
+
         prevalues = kwargs.get('ip_permissions', [kwargs])
 
         rule_ids = []
@@ -664,6 +670,8 @@ class CloudController(object):
 
         security_group = self.security_group_api.get(context, group_name,
                                                      group_id)
+
+        security_group_authorizer(context, security_group)
 
         prevalues = kwargs.get('ip_permissions', [kwargs])
         postvalues = []
@@ -736,6 +744,8 @@ class CloudController(object):
 
         security_group = self.security_group_api.get(context, group_name,
                                                      group_id)
+
+        security_group_authorizer(context, security_group)
 
         self.security_group_api.destroy(context, security_group)
 

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -4146,8 +4146,8 @@ class ComputeManager(manager.SchedulerDependentManager):
         # No instance booting at source host, but instance dir
         # must be deleted for preparing next block migration
         # must be deleted for preparing next live migration w/o shared storage
-        is_shared_block_storage = False
-        is_shared_instance_path = False
+        is_shared_block_storage = True
+        is_shared_instance_path = True
         if migrate_data:
             is_shared_block_storage = migrate_data.get(
                     'is_shared_block_storage', True)
@@ -4156,7 +4156,8 @@ class ComputeManager(manager.SchedulerDependentManager):
 
         if block_migration or not is_shared_instance_path:
             self.driver.destroy(instance_ref, network_info,
-                    destroy_disks = not is_shared_block_storage)
+                    destroy_disks=not is_shared_block_storage,
+                    migrate_data=migrate_data)
         else:
             # self.driver.destroy() usually performs  vif unplugging
             # but we must do it explicitly here when block_migration
@@ -4288,9 +4289,10 @@ class ComputeManager(manager.SchedulerDependentManager):
                     'is_shared_block_storage', True)
             is_shared_instance_path = migrate_data.get(
                     'is_shared_instance_path', True)
-        if block_migration or (is_shared_block_storage and not is_shared_instance_path):
+        if block_migration or (
+                is_shared_block_storage and not is_shared_instance_path):
             self.compute_rpcapi.rollback_live_migration_at_destination(context,
-                    instance, dest, destroy_disks = not is_shared_block_storage)
+                    instance, dest, destroy_disks=not is_shared_block_storage)
 
         self._notify_about_instance_usage(context, instance,
                                           "live_migration._rollback.end")

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -4146,11 +4146,17 @@ class ComputeManager(manager.SchedulerDependentManager):
         # No instance booting at source host, but instance dir
         # must be deleted for preparing next block migration
         # must be deleted for preparing next live migration w/o shared storage
-        is_shared_storage = True
+        is_shared_block_storage = False
+        is_shared_instance_path = False
         if migrate_data:
-            is_shared_storage = migrate_data.get('is_shared_storage', True)
-        if block_migration or not is_shared_storage:
-            self.driver.destroy(instance_ref, network_info)
+            is_shared_block_storage = migrate_data.get(
+                    'is_shared_block_storage', True)
+            is_shared_instance_path = migrate_data.get(
+                    'is_shared_instance_path', True)
+
+        if block_migration or not is_shared_instance_path:
+            self.driver.destroy(instance_ref, network_info,
+                    destroy_disks = not is_shared_block_storage)
         else:
             # self.driver.destroy() usually performs  vif unplugging
             # but we must do it explicitly here when block_migration
@@ -4275,20 +4281,23 @@ class ComputeManager(manager.SchedulerDependentManager):
         # Also Volume backed live migration w/o shared storage needs to delete
         # newly created instance-xxx dir on the destination as a part of its
         # rollback process
-        is_volume_backed = False
-        is_shared_storage = True
+        is_shared_block_storage = False
+        is_shared_instance_path = False
         if migrate_data:
-            is_volume_backed = migrate_data.get('is_volume_backed', False)
-            is_shared_storage = migrate_data.get('is_shared_storage', True)
-        if block_migration or (is_volume_backed and not is_shared_storage):
+            is_shared_block_storage = migrate_data.get(
+                    'is_shared_block_storage', True)
+            is_shared_instance_path = migrate_data.get(
+                    'is_shared_instance_path', True)
+        if block_migration or (is_shared_block_storage and not is_shared_instance_path):
             self.compute_rpcapi.rollback_live_migration_at_destination(context,
-                    instance, dest)
+                    instance, dest, destroy_disks = not is_shared_block_storage)
 
         self._notify_about_instance_usage(context, instance,
                                           "live_migration._rollback.end")
 
     @wrap_exception()
-    def rollback_live_migration_at_destination(self, context, instance):
+    def rollback_live_migration_at_destination(self, context, instance,
+                                               destroy_disks=True):
         """Cleaning up image directory that is created pre_live_migration.
 
         :param context: security context
@@ -4307,7 +4316,8 @@ class ComputeManager(manager.SchedulerDependentManager):
         #             from remote volumes if necessary
         block_device_info = self._get_instance_volume_block_device_info(
                             context, instance)
-        self.driver.destroy(instance, network_info, block_device_info)
+        self.driver.destroy(instance, network_info, block_device_info,
+                            destroy_disks)
         self._notify_about_instance_usage(
                         context, instance, "live_migration.rollback.dest.end",
                         network_info=network_info)

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -668,9 +668,10 @@ class ComputeManager(manager.SchedulerDependentManager):
                 return
 
         net_info = compute_utils.get_nw_info_for_instance(instance)
-
-        self.driver.plug_vifs(instance, net_info)
-
+        try:
+            self.driver.plug_vifs(instance, net_info)
+        except NotImplementedError as e:
+            LOG.debug(e, instance=instance)
         if instance['task_state'] == task_states.RESIZE_MIGRATING:
             # We crashed during resize/migration, so roll back for safety
             try:
@@ -4155,8 +4156,10 @@ class ComputeManager(manager.SchedulerDependentManager):
             # but we must do it explicitly here when block_migration
             # is false, as the network devices at the source must be
             # torn down
-            self.driver.unplug_vifs(instance_ref, network_info)
-
+            try:
+                self.driver.unplug_vifs(instance_ref, network_info)
+            except NotImplementedError as e:
+                LOG.debug(e, instance=instance_ref)
         # NOTE(tr3buchet): tear down networks on source host
         self.network_api.setup_networks_on_host(ctxt, instance_ref,
                                                 self.host, teardown=True)

--- a/nova/compute/rpcapi.py
+++ b/nova/compute/rpcapi.py
@@ -682,12 +682,13 @@ class ComputeAPI(rpcclient.RpcProxy):
                    instance=instance, migration=migration,
                    reservations=reservations)
 
-    def rollback_live_migration_at_destination(self, ctxt, instance, host):
+    def rollback_live_migration_at_destination(self, ctxt, instance, host,
+                                               destroy_disks=True):
         instance_p = jsonutils.to_primitive(instance)
         cctxt = self.client.prepare(server=host,
                 version=_get_version('2.0'))
         cctxt.cast(ctxt, 'rollback_live_migration_at_destination',
-                   instance=instance_p)
+                   instance=instance_p, destroy_disks=destroy_disks)
 
     def run_instance(self, ctxt, instance, host, request_spec,
                      filter_properties, requested_networks,

--- a/nova/image/glance.py
+++ b/nova/image/glance.py
@@ -295,7 +295,7 @@ class GlanceImageService(object):
         base_image_meta = self._translate_from_glance(image)
         return base_image_meta
 
-    def _get_locations(self, context, image_id):
+    def get_locations(self, context, image_id):
         """Returns the direct url representing the backend storage location,
         or None if this attribute is not shown by Glance.
         """
@@ -327,7 +327,7 @@ class GlanceImageService(object):
     def download(self, context, image_id, data=None, dst_path=None):
         """Calls out to Glance for data and writes data."""
         if CONF.allowed_direct_url_schemes and dst_path is not None:
-            locations = self._get_locations(context, image_id)
+            locations = self.get_locations(context, image_id)
             for entry in locations:
                 loc_url = entry['url']
                 loc_meta = entry['metadata']

--- a/nova/network/neutronv2/api.py
+++ b/nova/network/neutronv2/api.py
@@ -422,6 +422,13 @@ class API(base.Base):
                         LOG.exception(_("Failed to delete neutron port %s"),
                                       port)
 
+        # NOTE(arosen): This clears out the network_cache only if the instance
+        # hasn't already been deleted. This is needed when an instance fails to
+        # launch and is rescheduled onto another compute node. If the instance
+        # has already been deleted this call does nothing.
+        update_instance_info_cache(self, context, instance,
+                                   network_model.NetworkInfo([]))
+
     def allocate_port_for_instance(self, context, instance, port_id,
                                    network_id=None, requested_ip=None,
                                    conductor_api=None):

--- a/nova/network/security_group/neutron_driver.py
+++ b/nova/network/security_group/neutron_driver.py
@@ -112,12 +112,12 @@ class SecurityGroupAPI(security_group_base.SecurityGroupBase):
         nova_rule['protocol'] = rule['protocol']
         if (nova_rule['protocol'] and rule.get('port_range_min') is None and
                 rule.get('port_range_max') is None):
-            if nova_rule['protocol'].upper() == 'ICMP':
-                nova_rule['from_port'] = -1
-                nova_rule['to_port'] = -1
-            elif rule['protocol'].upper() in ['TCP', 'UDP']:
+            if rule['protocol'].upper() in ['TCP', 'UDP']:
                 nova_rule['from_port'] = 1
                 nova_rule['to_port'] = 65535
+            else:
+                nova_rule['from_port'] = -1
+                nova_rule['to_port'] = -1
         else:
             nova_rule['from_port'] = rule.get('port_range_min')
             nova_rule['to_port'] = rule.get('port_range_max')

--- a/nova/openstack/common/rpc/impl_qpid.py
+++ b/nova/openstack/common/rpc/impl_qpid.py
@@ -502,7 +502,7 @@ class Connection(object):
             if self.connection.opened():
                 try:
                     self.connection.close()
-                except qpid_exceptions.ConnectionError:
+                except qpid_exceptions.MessagingError:
                     pass
 
             broker = self.brokers[attempt % len(self.brokers)]
@@ -511,7 +511,7 @@ class Connection(object):
             try:
                 self.connection_create(broker)
                 self.connection.open()
-            except qpid_exceptions.ConnectionError as e:
+            except qpid_exceptions.MessagingError as e:
                 msg_dict = dict(e=e, delay=delay)
                 msg = _("Unable to connect to AMQP server: %(e)s. "
                         "Sleeping %(delay)s seconds") % msg_dict
@@ -539,7 +539,7 @@ class Connection(object):
             try:
                 return method(*args, **kwargs)
             except (qpid_exceptions.Empty,
-                    qpid_exceptions.ConnectionError) as e:
+                    qpid_exceptions.MessagingError) as e:
                 if error_callback:
                     error_callback(e)
                 self.reconnect()

--- a/nova/tests/compute/test_compute.py
+++ b/nova/tests/compute/test_compute.py
@@ -4438,7 +4438,7 @@ class ComputeTestCase(BaseTestCase):
         fake_notifier.NOTIFICATIONS = []
         # start test
         self.mox.ReplayAll()
-        migrate_data = {'is_shared_storage': False}
+        migrate_data = {'is_shared_instance_path': False}
         ret = self.compute.pre_live_migration(c, instance=instance,
                                               block_migration=False,
                                               migrate_data=migrate_data)
@@ -4500,7 +4500,7 @@ class ComputeTestCase(BaseTestCase):
         self.compute.compute_rpcapi.remove_volume_connection(
                 c, updated_instance, 'vol2-id', dest_host)
         self.compute.compute_rpcapi.rollback_live_migration_at_destination(
-                c, updated_instance, dest_host)
+                c, updated_instance, dest_host, destroy_disks=True)
 
         # start test
         self.mox.ReplayAll()
@@ -4520,7 +4520,7 @@ class ComputeTestCase(BaseTestCase):
 
         instance = jsonutils.to_primitive(instance_ref)
 
-        migrate_data = {'is_shared_storage': False}
+        migrate_data = {'is_shared_instance_path': False}
 
         self.mox.StubOutWithMock(self.compute.compute_rpcapi,
                                  'pre_live_migration')
@@ -4600,7 +4600,7 @@ class ComputeTestCase(BaseTestCase):
 
         # start test
         self.mox.ReplayAll()
-        migrate_data = {'is_shared_storage': False}
+        migrate_data = {'is_shared_instance_path': False}
         self.compute._post_live_migration(c, inst_ref, dest,
                                           migrate_data=migrate_data)
         self.assertTrue('destroyed' in result)

--- a/nova/tests/compute/test_rpcapi.py
+++ b/nova/tests/compute/test_rpcapi.py
@@ -340,7 +340,8 @@ class ComputeRpcAPITestCase(test.TestCase):
 
     def test_rollback_live_migration_at_destination(self):
         self._test_compute_api('rollback_live_migration_at_destination',
-                'cast', instance=self.fake_instance, host='host')
+                'cast', instance=self.fake_instance, host='host',
+                destroy_disks=True)
 
     def test_run_instance(self):
         self._test_compute_api('run_instance', 'cast',

--- a/nova/tests/network/security_group/test_neutron_driver.py
+++ b/nova/tests/network/security_group/test_neutron_driver.py
@@ -84,6 +84,39 @@ class TestNeutronDriver(test.NoDBTestCase):
         self.assertRaises(exception.SecurityGroupLimitExceeded,
                           sg_api.add_rules, self.context, None, name, [vals])
 
+    def test_list_security_group_with_no_port_range_and_not_tcp_udp_icmp(self):
+        sg1 = {'description': 'default',
+               'id': '07f1362f-34f6-4136-819a-2dcde112269e',
+               'name': 'default',
+               'tenant_id': 'c166d9316f814891bcb66b96c4c891d6',
+               'security_group_rules':
+                   [{'direction': 'ingress',
+                     'ethertype': 'IPv4',
+                     'id': '0a4647f1-e1aa-488d-90e1-97a7d0293beb',
+                      'port_range_max': None,
+                      'port_range_min': None,
+                      'protocol': '51',
+                      'remote_group_id': None,
+                      'remote_ip_prefix': None,
+                      'security_group_id':
+                           '07f1362f-34f6-4136-819a-2dcde112269e',
+                      'tenant_id': 'c166d9316f814891bcb66b96c4c891d6'}]}
+
+        self.moxed_client.list_security_groups().AndReturn(
+            {'security_groups': [sg1]})
+        self.mox.ReplayAll()
+        sg_api = neutron_driver.SecurityGroupAPI()
+        result = sg_api.list(self.context)
+        expected = [{'rules':
+            [{'from_port': -1, 'protocol': '51', 'to_port': -1,
+              'parent_group_id': '07f1362f-34f6-4136-819a-2dcde112269e',
+              'cidr': '0.0.0.0/0', 'group_id': None,
+              'id': '0a4647f1-e1aa-488d-90e1-97a7d0293beb'}],
+            'project_id': 'c166d9316f814891bcb66b96c4c891d6',
+            'id': '07f1362f-34f6-4136-819a-2dcde112269e',
+            'name': 'default', 'description': 'default'}]
+        self.assertEqual(expected, result)
+
     def test_instances_security_group_bindings(self):
         server_id = 'c5a20e8d-c4b0-47cf-9dca-ebe4f758acb1'
         port1_id = '4c505aec-09aa-47bc-bcc0-940477e84dc0'

--- a/nova/tests/network/test_neutronv2.py
+++ b/nova/tests/network/test_neutronv2.py
@@ -876,6 +876,7 @@ class TestNeutronv2(TestNeutronv2Base):
                           self.instance, requested_networks=requested_networks)
 
     def _deallocate_for_instance(self, number):
+        api = neutronapi.API()
         port_data = number == 1 and self.port_data1 or self.port_data2
         self.moxed_client.list_ports(
             device_id=self.instance['uuid']).AndReturn(
@@ -883,6 +884,10 @@ class TestNeutronv2(TestNeutronv2Base):
         for port in reversed(port_data):
             self.moxed_client.delete_port(port['id'])
 
+        self.mox.StubOutWithMock(api.db, 'instance_info_cache_update')
+        api.db.instance_info_cache_update(self.context,
+                                          self.instance['uuid'],
+                                          {'network_info': '[]'})
         self.mox.ReplayAll()
 
         api = neutronapi.API()

--- a/nova/tests/virt/docker/test_driver.py
+++ b/nova/tests/virt/docker/test_driver.py
@@ -71,3 +71,17 @@ class DockerDriverTestCase(_VirtDriverTestCase, test.TestCase):
                          self.connection.get_host_stats()['host_hostname'])
         self.assertEqual('foo',
                          self.connection.get_host_stats()['host_hostname'])
+
+    def test_plug_vifs(self):
+        # Check to make sure the method raises NotImplementedError.
+        self.assertRaises(NotImplementedError,
+                          self.connection.plug_vifs,
+                          instance=utils.get_test_instance(),
+                          network_info=None)
+
+    def test_unplug_vifs(self):
+        # Check to make sure the method raises NotImplementedError.
+        self.assertRaises(NotImplementedError,
+                          self.connection.unplug_vifs,
+                          instance=utils.get_test_instance(),
+                          network_info=None)

--- a/nova/tests/virt/hyperv/test_hypervapi.py
+++ b/nova/tests/virt/hyperv/test_hypervapi.py
@@ -1664,3 +1664,17 @@ class VolumeOpsTestCase(HyperVAPITestCase):
             self.assertRaises(exception.NotFound,
                               self.volumeops._get_mounted_disk_from_lun,
                               target_iqn, target_lun)
+
+    def test_plug_vifs(self):
+        # Check to make sure the method raises NotImplementedError.
+        self.assertRaises(NotImplementedError,
+                          self._conn.plug_vifs,
+                          instance=self._test_spawn_instance,
+                          network_info=None)
+
+    def test_unplug_vifs(self):
+        # Check to make sure the method raises NotImplementedError.
+        self.assertRaises(NotImplementedError,
+                          self._conn.unplug_vifs,
+                          instance=self._test_spawn_instance,
+                          network_info=None)

--- a/nova/tests/virt/libvirt/fake_libvirt_utils.py
+++ b/nova/tests/virt/libvirt/fake_libvirt_utils.py
@@ -211,8 +211,10 @@ def pick_disk_driver_name(hypervisor_version, is_block_dev=False):
 
 
 def list_rbd_volumes(pool):
-    fake_volumes = ['fakeinstancename.local', 'fakeinstancename.swap',
-                    'fakeinstancename', 'wronginstancename']
+    fake_volumes = ['875a8070-d0b9-4949-8b31-104d125c9a64.local',
+                    '875a8070-d0b9-4949-8b31-104d125c9a64.swap',
+                    '875a8070-d0b9-4949-8b31-104d125c9a64',
+                    'wrong875a8070-d0b9-4949-8b31-104d125c9a64']
     return fake_volumes
 
 

--- a/nova/tests/virt/libvirt/fake_libvirt_utils.py
+++ b/nova/tests/virt/libvirt/fake_libvirt_utils.py
@@ -220,3 +220,7 @@ def list_rbd_volumes(pool):
 
 def remove_rbd_volumes(pool, *names):
     pass
+
+
+def ascii_str(s):
+    return libvirt_utils.ascii_str(s)

--- a/nova/tests/virt/libvirt/test_imagebackend.py
+++ b/nova/tests/virt/libvirt/test_imagebackend.py
@@ -736,10 +736,12 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
         self.libvirt_utils = imagebackend.libvirt_utils
         self.utils = imagebackend.utils
         self.rbd = self.mox.CreateMockAnything()
+        self.rados = self.mox.CreateMockAnything()
 
     def prepare_mocks(self):
         fn = self.mox.CreateMockAnything()
         self.mox.StubOutWithMock(imagebackend, 'rbd')
+        self.mox.StubOutWithMock(imagebackend, 'rados')
         return fn
 
     def test_cache(self):
@@ -830,6 +832,9 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
 
         self.rbd.RBD_FEATURE_LAYERING = 1
 
+        self.mox.StubOutWithMock(imagebackend.disk, 'get_disk_size')
+        imagebackend.disk.get_disk_size(self.TEMPLATE_PATH
+                                       ).AndReturn(self.SIZE)
         rbd_name = "%s/%s" % (self.INSTANCE['name'], self.NAME)
         cmd = ('--pool', self.POOL, self.TEMPLATE_PATH,
                rbd_name, '--new-format', '--id', self.USER,
@@ -848,9 +853,13 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
         fake_processutils.fake_execute_clear_log()
         fake_processutils.stub_out_processutils_execute(self.stubs)
         self.mox.StubOutWithMock(imagebackend, 'rbd')
+        self.mox.StubOutWithMock(imagebackend, 'rados')
         image = self.image_class(self.INSTANCE, self.NAME)
 
         def fake_fetch(target, *args, **kwargs):
+            return
+
+        def fake_resize(rbd_name, size):
             return
 
         self.stubs.Set(os.path, 'exists', lambda _: True)

--- a/nova/tests/virt/libvirt/test_imagebackend.py
+++ b/nova/tests/virt/libvirt/test_imagebackend.py
@@ -977,6 +977,21 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
 
         self.assertFalse(image._is_cloneable(location))
 
+    def test_image_path(self):
+
+        conf = "FakeConf"
+        pool = "FakePool"
+        user = "FakeUser"
+
+        self.flags(libvirt_images_rbd_pool=pool)
+        self.flags(libvirt_images_rbd_ceph_conf=conf)
+        self.flags(rbd_user=user)
+        image = self.image_class(self.INSTANCE, self.NAME)
+        rbd_path = "rbd:%s/%s:id=%s:conf=%s" % (pool, image.rbd_name,
+                                                user, conf)
+
+        self.assertEqual(image.path, rbd_path)
+
 
 class BackendTestCase(test.NoDBTestCase):
     INSTANCE = {'name': 'fake-instance',

--- a/nova/tests/virt/libvirt/test_imagebackend.py
+++ b/nova/tests/virt/libvirt/test_imagebackend.py
@@ -402,14 +402,14 @@ class Qcow2TestCase(_ImageTestCase, test.NoDBTestCase):
     def test_create_image_too_small(self):
         fn = self.prepare_mocks()
         self.mox.StubOutWithMock(os.path, 'exists')
-        self.mox.StubOutWithMock(imagebackend.disk, 'get_disk_size')
+        self.mox.StubOutWithMock(imagebackend.Qcow2, 'get_disk_size')
         if self.OLD_STYLE_INSTANCE_PATH:
             os.path.exists(self.OLD_STYLE_INSTANCE_PATH).AndReturn(False)
         os.path.exists(self.DISK_INFO_PATH).AndReturn(False)
         os.path.exists(self.INSTANCES_PATH).AndReturn(True)
         os.path.exists(self.TEMPLATE_PATH).AndReturn(True)
-        imagebackend.disk.get_disk_size(self.TEMPLATE_PATH
-                                       ).AndReturn(self.SIZE)
+        imagebackend.Qcow2.get_disk_size(self.TEMPLATE_PATH
+                                         ).AndReturn(self.SIZE)
         self.mox.ReplayAll()
 
         image = self.image_class(self.INSTANCE, self.NAME)

--- a/nova/tests/virt/libvirt/test_imagebackend.py
+++ b/nova/tests/virt/libvirt/test_imagebackend.py
@@ -832,9 +832,6 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
 
         self.rbd.RBD_FEATURE_LAYERING = 1
 
-        self.mox.StubOutWithMock(imagebackend.disk, 'get_disk_size')
-        imagebackend.disk.get_disk_size(self.TEMPLATE_PATH
-                                       ).AndReturn(self.SIZE)
         rbd_name = "%s/%s" % (self.INSTANCE['name'], self.NAME)
         cmd = ('--pool', self.POOL, self.TEMPLATE_PATH,
                rbd_name, '--new-format', '--id', self.USER,
@@ -872,6 +869,113 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
     def test_parent_compatible(self):
         self.assertEqual(getargspec(imagebackend.Image.libvirt_info),
              getargspec(self.image_class.libvirt_info))
+
+    def test_direct_fetch(self):
+        self.prepare_mocks()
+        self.rbd.RBD_FEATURE_LAYERING = 1
+
+        image = self.image_class(self.INSTANCE, self.NAME)
+        self.mox.StubOutWithMock(image, '_clone')
+        image._clone('b', 'c', 'd')
+        self.mox.ReplayAll()
+
+        def fake_parse_location(url):
+            return 'a', 'b', 'c', 'd'
+
+        self.stubs.Set(image, 'check_image_exists', lambda: False)
+        self.stubs.Set(image, '_is_cloneable', lambda x: True)
+        self.stubs.Set(image, '_parse_location', fake_parse_location)
+
+        image.direct_fetch('image_id',
+                           {'disk_format': 'raw'},
+                           [{'url': 'rbd://a/b/c/d'}])
+
+        self.mox.VerifyAll()
+
+    def test_direct_fetch_fail(self):
+        image = self.image_class(self.INSTANCE, self.NAME)
+        self.stubs.Set(image, '_is_cloneable', lambda: True)
+        self.assertRaises(exception.ImageUnacceptable,
+                          image.direct_fetch, 'image_id',
+                          {'disk_format': 'raw'},
+                          [{'url': 'rbd://a/b/c/d'}])
+        self.rbd.RBD_FEATURE_LAYERING = 1
+        self.assertRaises(exception.ImageUnacceptable,
+                          image.direct_fetch, 'image_id',
+                          {},
+                          [{'url': 'rbd://a/b/c/d'}])
+        self.assertRaises(exception.ImageUnacceptable,
+                          image.direct_fetch, 'image_id',
+                          {'disk_format': 'raw'},
+                          [])
+        self.stubs.Set(image, '_is_cloneable', lambda: False)
+        self.assertRaises(exception.ImageUnacceptable,
+                          image.direct_fetch, 'image_id',
+                          {'disk_format': 'raw'},
+                          [{'url': 'rbd://a/b/c/d'}])
+
+    def test_good_locations(self):
+        image = self.image_class(self.INSTANCE, self.NAME)
+        locations = ['rbd://fsid/pool/image/snap',
+                     'rbd://%2F/%2F/%2F/%2F', ]
+        map(image._parse_location, locations)
+
+    def test_bad_locations(self):
+        image = self.image_class(self.INSTANCE, self.NAME)
+        locations = ['rbd://image',
+                     'http://path/to/somewhere/else',
+                     'rbd://image/extra',
+                     'rbd://image/',
+                     'rbd://fsid/pool/image/',
+                     'rbd://fsid/pool/image/snap/',
+                     'rbd://///', ]
+        for loc in locations:
+            self.assertRaises(exception.ImageUnacceptable,
+                              image._parse_location,
+                              loc)
+            self.assertFalse(image._is_cloneable(loc))
+
+    def test_cloneable(self):
+        image = self.image_class(self.INSTANCE, self.NAME)
+        self.stubs.Set(image, '_get_fsid', lambda: 'abc')
+        location = u'rbd://abc/pool/image/snap'
+        mock_proxy = self.mox.CreateMockAnything()
+        self.mox.StubOutWithMock(imagebackend, 'RBDVolumeProxy')
+
+        imagebackend.RBDVolumeProxy(image, 'image',
+                                    pool='pool',
+                                    snapshot='snap',
+                                    read_only=True).AndReturn(mock_proxy)
+        mock_proxy.__enter__().AndReturn(mock_proxy)
+        mock_proxy.__exit__(None, None, None).AndReturn(None)
+
+        self.mox.ReplayAll()
+
+        self.assertTrue(image._is_cloneable(location))
+
+    def test_uncloneable_different_fsid(self):
+        image = self.image_class(self.INSTANCE, self.NAME)
+        self.stubs.Set(image, '_get_fsid', lambda: 'abc')
+        location = 'rbd://def/pool/image/snap'
+        self.assertFalse(image._is_cloneable(location))
+
+    def test_uncloneable_unreadable(self):
+        self.prepare_mocks()
+        image = self.image_class(self.INSTANCE, self.NAME, rbd=self.rbd)
+        self.stubs.Set(image, '_get_fsid', lambda: 'abc')
+        location = 'rbd://abc/pool/image/snap'
+        self.stubs.Set(self.rbd, 'Error', test.TestingException)
+        self.mox.StubOutWithMock(imagebackend, 'RBDVolumeProxy')
+
+        imagebackend.RBDVolumeProxy(image, 'image',
+                                    pool='pool',
+                                    snapshot='snap',
+                                    read_only=True).AndRaise(
+            test.TestingException)
+
+        self.mox.ReplayAll()
+
+        self.assertFalse(image._is_cloneable(location))
 
 
 class BackendTestCase(test.NoDBTestCase):

--- a/nova/tests/virt/libvirt/test_libvirt.py
+++ b/nova/tests/virt/libvirt/test_libvirt.py
@@ -4369,8 +4369,10 @@ class LibvirtConnTestCase(test.TestCase):
         def fake_get_info(instance_name):
             return {'state': power_state.SHUTDOWN, 'id': -1}
 
-        fake_volumes = ['fakeinstancename.local', 'fakeinstancename.swap',
-                        'fakeinstancename', 'wronginstancename']
+        fake_volumes = ['875a8070-d0b9-4949-8b31-104d125c9a64.local',
+                        '875a8070-d0b9-4949-8b31-104d125c9a64.swap',
+                        '875a8070-d0b9-4949-8b31-104d125c9a64',
+                        'wrong875a8070-d0b9-4949-8b31-104d125c9a64']
         fake_pool = 'fake_pool'
         fake_instance = {'name': 'fakeinstancename', 'id': 'instanceid',
                          'uuid': '875a8070-d0b9-4949-8b31-104d125c9a64'}

--- a/nova/tests/virt/libvirt/test_libvirt.py
+++ b/nova/tests/virt/libvirt/test_libvirt.py
@@ -2906,7 +2906,7 @@ class LibvirtConnTestCase(test.TestCase):
         ret = conn.check_can_live_migrate_source(self.context, instance_ref,
                                                  dest_check_data)
         self.assertTrue(type(ret) == dict)
-        self.assertTrue('is_shared_storage' in ret)
+        self.assertTrue('is_shared_instance_path' in ret)
 
     def test_check_can_live_migrate_source_vol_backed_w_disk_raises(self):
         instance_ref = db.instance_create(self.context, self.test_instance)
@@ -3198,7 +3198,7 @@ class LibvirtConnTestCase(test.TestCase):
             self.mox.StubOutWithMock(conn, 'plug_vifs')
             conn.plug_vifs(mox.IsA(inst_ref), nw_info)
             self.mox.ReplayAll()
-            migrate_data = {'is_shared_storage': False,
+            migrate_data = {'is_shared_instance_path': False,
                             'is_volume_backed': True,
                             'block_migration': False,
                             'instance_relative_path': inst_ref['name']

--- a/nova/tests/virt/powervm/test_powervm.py
+++ b/nova/tests/virt/powervm/test_powervm.py
@@ -819,10 +819,16 @@ class PowerVMDriverTestCase(test.TestCase):
                     aggregate={'name': 'foo'}, host='fake')
 
     def test_plug_vifs(self):
-        # Check to make sure the method passes (does nothing) since
-        # it simply passes in the powervm driver but it raises a
-        # NotImplementedError in the base driver class.
-        self.powervm_connection.plug_vifs(self.instance, None)
+        # Check to make sure the method raises NotImplementedError.
+        self.assertRaises(NotImplementedError,
+                          self.powervm_connection.plug_vifs,
+                          instance=self.instance, network_info=None)
+
+    def test_unplug_vifs(self):
+        # Check to make sure the method raises NotImplementedError.
+        self.assertRaises(NotImplementedError,
+                          self.powervm_connection.unplug_vifs,
+                          instance=self.instance, network_info=None)
 
     def test_manage_image_cache(self):
         # Check to make sure the method passes (does nothing) since

--- a/nova/tests/virt/vmwareapi/stubs.py
+++ b/nova/tests/virt/vmwareapi/stubs.py
@@ -23,7 +23,6 @@ from nova.virt.vmwareapi import driver
 from nova.virt.vmwareapi import error_util
 from nova.virt.vmwareapi import fake
 from nova.virt.vmwareapi import network_util
-from nova.virt.vmwareapi import vmops
 from nova.virt.vmwareapi import vmware_images
 
 
@@ -50,7 +49,6 @@ def fake_temp_session_exception():
 
 def set_stubs(stubs):
     """Set the stubs."""
-    stubs.Set(vmops.VMwareVMOps, 'plug_vifs', fake.fake_plug_vifs)
     stubs.Set(network_util, 'get_network_with_the_name',
               fake.fake_get_network)
     stubs.Set(vmware_images, 'fetch_image', fake.fake_fetch_image)

--- a/nova/tests/virt/vmwareapi/test_vmwareapi.py
+++ b/nova/tests/virt/vmwareapi/test_vmwareapi.py
@@ -809,9 +809,18 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
         self.assertEquals(self.conn.destroy(self.instance, self.network_info),
                           None)
 
-    def _rescue(self):
+    def _rescue(self, config_drive=False):
         def fake_attach_disk_to_vm(*args, **kwargs):
             pass
+
+        if config_drive:
+            def fake_create_config_drive(instance, injected_files, password,
+                                         data_store_name, dc_name,
+                                         instance_uuid, cookies):
+                self.assertTrue(uuidutils.is_uuid_like(instance['uuid']))
+
+            self.stubs.Set(self.conn._vmops, '_create_config_drive',
+                           fake_create_config_drive)
 
         self._create_vm()
         info = self.conn.get_info({'name': 1, 'uuid': self.uuid,
@@ -820,7 +829,7 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
                        fake_attach_disk_to_vm)
         self.conn.rescue(self.context, self.instance, self.network_info,
                          self.image, 'fake-password')
-        info = self.conn.get_info({'name-rescue': 1,
+        info = self.conn.get_info({'name': '1-rescue',
                                    'uuid': '%s-rescue' % self.uuid,
                                    'node': self.instance_node})
         self._check_vm_info(info, power_state.RUNNING)
@@ -831,8 +840,19 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
     def test_rescue(self):
         self._rescue()
 
+    def test_rescue_with_config_drive(self):
+        self.flags(force_config_drive=True)
+        self._rescue(config_drive=True)
+
     def test_unrescue(self):
         self._rescue()
+
+        def fake_detach_disk_from_vm(*args, **kwargs):
+            pass
+
+        self.stubs.Set(self.conn._volumeops, "detach_disk_from_vm",
+                       fake_detach_disk_from_vm)
+
         self.conn.unrescue(self.instance, None)
         info = self.conn.get_info({'name': 1, 'uuid': self.uuid,
                                    'node': self.instance_node})

--- a/nova/tests/virt/vmwareapi/test_vmwareapi.py
+++ b/nova/tests/virt/vmwareapi/test_vmwareapi.py
@@ -1441,3 +1441,17 @@ class VMwareAPIVCDriverTestCase(VMwareAPIVMTestCase):
         self._create_vm()
         # currently there are 2 data stores
         self.assertEqual(2, len(vmops._datastore_dc_mapping))
+
+    def test_plug_vifs(self):
+        # Check to make sure the method raises NotImplementedError.
+        self._create_instance_in_the_db()
+        self.assertRaises(NotImplementedError,
+                          self.conn.plug_vifs,
+                          instance=self.instance, network_info=None)
+
+    def test_unplug_vifs(self):
+        # Check to make sure the method raises NotImplementedError.
+        self._create_instance_in_the_db()
+        self.assertRaises(NotImplementedError,
+                          self.conn.unplug_vifs,
+                          instance=self.instance, network_info=None)

--- a/nova/tests/virt/vmwareapi/test_vmwareapi_vm_util.py
+++ b/nova/tests/virt/vmwareapi/test_vmwareapi_vm_util.py
@@ -21,6 +21,7 @@ import re
 
 from nova import exception
 from nova.openstack.common.gettextutils import _
+from nova.openstack.common import uuidutils
 from nova import test
 from nova.virt.vmwareapi import fake
 from nova.virt.vmwareapi import vm_util
@@ -463,3 +464,32 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
 
     def test_detach_virtual_disk_destroy_spec(self):
         self._test_detach_virtual_disk_spec(destroy_disk=True)
+
+    def test_get_vm_create_spec(self):
+        instance_uuid = uuidutils.generate_uuid()
+        fake_instance = {'id': 7, 'name': 'fake!',
+                         'uuid': instance_uuid,
+                         'vcpus': 2, 'memory_mb': 2048}
+        result = vm_util.get_vm_create_spec(fake.FakeFactory(),
+                                            fake_instance, 'fake-name',
+                                            'fake-datastore', [])
+        expected = """{
+            'files': {'vmPathName': '[fake-datastore]',
+            'obj_name': 'ns0:VirtualMachineFileInfo'},
+            'name': 'fake-name', 'deviceChange': [],
+            'extraConfig': [{'value': '%s',
+                             'key': 'nvp.vm-uuid',
+                             'obj_name': 'ns0:OptionValue'}],
+            'memoryMB': 2048,
+            'obj_name': 'ns0:VirtualMachineConfigSpec',
+            'guestId': 'otherGuest',
+            'tools': {'beforeGuestStandby': True,
+                      'beforeGuestReboot': True,
+                      'beforeGuestShutdown': True,
+                      'afterResume': True,
+                      'afterPowerOn': True,
+            'obj_name': 'ns0:ToolsConfigInfo'},
+            'numCPUs': 2}""" % instance_uuid
+        expected = re.sub(r'\s+', '', expected)
+        result = re.sub(r'\s+', '', repr(result))
+        self.assertEqual(expected, result)

--- a/nova/virt/docker/driver.py
+++ b/nova/virt/docker/driver.py
@@ -99,11 +99,13 @@ class DockerDriver(driver.ComputeDriver):
 
     def plug_vifs(self, instance, network_info):
         """Plug VIFs into networks."""
-        pass
+        msg = _("VIF plugging is not supported by the Docker driver.")
+        raise NotImplementedError(msg)
 
     def unplug_vifs(self, instance, network_info):
         """Unplug VIFs from networks."""
-        pass
+        msg = _("VIF unplugging is not supported by the Docker driver.")
+        raise NotImplementedError(msg)
 
     def find_container_by_name(self, name):
         for info in self.list_instances(inspect=True):

--- a/nova/virt/driver.py
+++ b/nova/virt/driver.py
@@ -242,7 +242,7 @@ class ComputeDriver(object):
         raise NotImplementedError()
 
     def destroy(self, instance, network_info, block_device_info=None,
-                destroy_disks=True):
+                destroy_disks=True, migrate_data=None):
         """Destroy (shutdown and delete) the specified instance.
 
         If the instance is not found (for example if networking failed), this

--- a/nova/virt/fake.py
+++ b/nova/virt/fake.py
@@ -207,7 +207,7 @@ class FakeDriver(driver.ComputeDriver):
         pass
 
     def destroy(self, instance, network_info, block_device_info=None,
-                destroy_disks=True, context=None):
+                destroy_disks=True, context=None, migrate_data=None):
         key = instance['name']
         if key in self.instances:
             del self.instances[key]

--- a/nova/virt/hyperv/driver.py
+++ b/nova/virt/hyperv/driver.py
@@ -151,10 +151,14 @@ class HyperVDriver(driver.ComputeDriver):
             ctxt, instance_ref, dest_check_data)
 
     def plug_vifs(self, instance, network_info):
-        LOG.debug(_("plug_vifs called"), instance=instance)
+        """Plug VIFs into networks."""
+        msg = _("VIF plugging is not supported by the Hyper-V driver.")
+        raise NotImplementedError(msg)
 
     def unplug_vifs(self, instance, network_info):
-        LOG.debug(_("unplug_vifs called"), instance=instance)
+        """Unplug VIFs from networks."""
+        msg = _("VIF unplugging is not supported by the Hyper-V driver.")
+        raise NotImplementedError(msg)
 
     def ensure_filtering_rules_for_instance(self, instance_ref, network_info):
         LOG.debug(_("ensure_filtering_rules_for_instance called"),

--- a/nova/virt/images.py
+++ b/nova/virt/images.py
@@ -179,6 +179,26 @@ def convert_image(source, dest, out_format, run_as_root=False):
     utils.execute(*cmd, run_as_root=run_as_root)
 
 
+def direct_fetch(context, image_href, backend_dest, _user_id, _project_id,
+                 max_size=0):
+    """Allow an image backend to fetch directly from the glance backend.
+
+    :backend_dest: the image backend, which must have a direct_fetch
+                   method accepting a list of image locations. This method
+                   should raise exceptions.ImageUnacceptable if the image
+                   cannot be downloaded directly.
+    """
+    # TODO(jdurgin): improve auth handling as noted in fetch()
+    image_service, image_id = glance.get_remote_image_service(context,
+                                                              image_href)
+    locations = image_service.get_locations(context, image_id)
+    image_meta = image_service.show(context, image_id)
+
+    LOG.debug(_('Image locations are: %(locs)s') % {'locs': locations})
+    backend_dest.direct_fetch(image_id, image_meta, locations,
+                              max_size=max_size)
+
+
 def fetch(context, image_href, path, _user_id, _project_id, max_size=0):
     # TODO(vish): Improve context handling and add owner and auth data
     #             when it is added to glance.  Right now there is no

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -952,7 +952,7 @@ class LibvirtDriver(driver.ComputeDriver):
     def _cleanup_rbd(self, instance):
         pool = CONF.libvirt_images_rbd_pool
         volumes = libvirt_utils.list_rbd_volumes(pool)
-        pattern = instance['name']
+        pattern = instance['uuid']
 
         def belongs_to_instance(disk):
             return disk.startswith(pattern)

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -2380,13 +2380,15 @@ class LibvirtDriver(driver.ComputeDriver):
             if size == 0 or suffix == '.rescue':
                 size = None
 
-            image('disk').cache(fetch_func=libvirt_utils.fetch_image,
-                                context=context,
-                                filename=root_fname,
-                                size=size,
-                                image_id=disk_images['image_id'],
-                                user_id=instance['user_id'],
-                                project_id=instance['project_id'])
+            disk_image = image('disk')
+            disk_image.cache(fetch_func=libvirt_utils.fetch_image,
+                             context=context,
+                             filename=root_fname,
+                             size=size,
+                             backend_dest=disk_image,
+                             image_id=disk_images['image_id'],
+                             user_id=instance['user_id'],
+                             project_id=instance['project_id'])
 
         # Lookup the filesystem type if required
         os_type_with_default = disk.get_fs_type_for_os_type(

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -72,6 +72,8 @@ CONF = cfg.CONF
 CONF.register_opts(__imagebackend_opts)
 CONF.import_opt('base_dir_name', 'nova.virt.libvirt.imagecache')
 CONF.import_opt('preallocate_images', 'nova.virt.driver')
+CONF.import_opt('rbd_user', 'nova.virt.libvirt.volume')
+CONF.import_opt('rbd_secret_uuid', 'nova.virt.libvirt.volume')
 
 LOG = logging.getLogger(__name__)
 

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -594,6 +594,12 @@ class Rbd(Image):
         self.rbd = kwargs.get('rbd', rbd)
         self.rados = kwargs.get('rados', rados)
 
+        self.path = 'rbd:%s/%s' % (self.pool, self.rbd_name)
+        if self.rbd_user:
+            self.path += ':id=' + self.rbd_user
+        if self.ceph_conf:
+            self.path += ':conf=' + self.ceph_conf
+
     def _connect_to_rados(self, pool=None):
         client = self.rados.Rados(rados_id=self.rbd_user,
                                   conffile=self.ceph_conf)
@@ -726,8 +732,7 @@ class Rbd(Image):
         pass
 
     def snapshot_extract(self, target, out_format):
-        snap = 'rbd:%s/%s' % (self.pool, self.rbd_name)
-        images.convert_image(snap, target, out_format)
+        images.convert_image(self.path, target, out_format)
 
     def snapshot_delete(self):
         pass

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -659,7 +659,7 @@ class Rbd(Image):
         info = vconfig.LibvirtConfigGuestDisk()
 
         hosts, ports = self._get_mon_addrs()
-        info.device_type = device_type
+        info.source_device = device_type
         info.driver_format = 'raw'
         info.driver_cache = cache_mode
         info.target_bus = disk_bus
@@ -794,7 +794,7 @@ class Rbd(Image):
     def direct_fetch(self, image_id, image_meta, image_locations, max_size=0):
         if self.check_image_exists():
             return
-        if image_meta.get('disk_format') != 'raw':
+        if image_meta.get('disk_format') not in ['raw', 'iso']:
             reason = _('Image is not raw format')
             raise exception.ImageUnacceptable(image_id=image_id, reason=reason)
         if not self._supports_layering():

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -301,7 +301,7 @@ class Image(object):
             raise exception.DiskInfoReadWriteFail(reason=unicode(e))
         return driver_format
 
-    def direct_fetch(self, image_id, image_meta, image_locations):
+    def direct_fetch(self, image_id, image_meta, image_locations, max_size=0):
         """Create an image from a direct image location.
 
         :raises: exception.ImageUnacceptable if it cannot be fetched directly
@@ -793,7 +793,7 @@ class Rbd(Image):
                                      self.rbd_name,
                                      features=self.rbd.RBD_FEATURE_LAYERING)
 
-    def direct_fetch(self, image_id, image_meta, image_locations):
+    def direct_fetch(self, image_id, image_meta, image_locations, max_size=0):
         if self.check_image_exists():
             return
         if image_meta.get('disk_format') != 'raw':

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -201,8 +201,7 @@ class Image(object):
                           (CONF.preallocate_images, self.path))
         return can_fallocate
 
-    @staticmethod
-    def verify_base_size(base, size, base_size=0):
+    def verify_base_size(self, base, size, base_size=0):
         """Check that the base image is not larger than size.
            Since images can't be generally shrunk, enforce this
            constraint taking account of virtual image size.
@@ -221,7 +220,7 @@ class Image(object):
             return
 
         if size and not base_size:
-            base_size = disk.get_disk_size(base)
+            base_size = self.get_disk_size(base)
 
         if size < base_size:
             msg = _('%(base)s virtual size %(base_size)s '
@@ -230,6 +229,9 @@ class Image(object):
                               'base_size': base_size,
                               'size': size})
             raise exception.InstanceTypeDiskTooSmall()
+
+    def get_disk_size(self, name):
+        disk.get_disk_size(name)
 
     def snapshot_create(self):
         raise NotImplementedError()
@@ -695,7 +697,10 @@ class Rbd(Image):
             vol.resize(int(size))
 
     def _size(self):
-        with RBDVolumeProxy(self, self.rbd_name) as vol:
+        return self.get_disk_size(self.rbd_name)
+
+    def get_disk_size(self, name):
+        with RBDVolumeProxy(self, name) as vol:
             return vol.size()
 
     def create_image(self, prepare_template, base, size, *args, **kwargs):

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -534,7 +534,8 @@ class RBDVolumeProxy(object):
         client, ioctx = driver._connect_to_rados(pool)
         try:
             self.volume = driver.rbd.Image(ioctx, str(name),
-                                           snapshot=ascii_str(snapshot),
+                                           snapshot=libvirt_utils.ascii_str(
+                                                        snapshot),
                                            read_only=read_only)
         except driver.rbd.Error:
             LOG.exception(_("error opening rbd image %s"), name)
@@ -570,17 +571,6 @@ class RADOSClient(object):
         self.driver._disconnect_from_rados(self.cluster, self.ioctx)
 
 
-def ascii_str(s):
-    """Convert a string to ascii, or return None if the input is None.
-
-    This is useful when a parameter is None by default, or a string. LibRBD
-    only accepts ascii, hence the need for conversion.
-    """
-    if s is None:
-        return s
-    return str(s)
-
-
 class Rbd(Image):
     def __init__(self, instance=None, disk_name=None, path=None,
                  snapshot_name=None, **kwargs):
@@ -598,8 +588,9 @@ class Rbd(Image):
                                  ' libvirt_images_rbd_pool'
                                  ' flag to use rbd images.'))
         self.pool = str(CONF.libvirt_images_rbd_pool)
-        self.ceph_conf = ascii_str(CONF.libvirt_images_rbd_ceph_conf)
-        self.rbd_user = ascii_str(CONF.rbd_user)
+        self.ceph_conf = libvirt_utils.ascii_str(
+                         CONF.libvirt_images_rbd_ceph_conf)
+        self.rbd_user = libvirt_utils.ascii_str(CONF.rbd_user)
         self.rbd = kwargs.get('rbd', rbd)
         self.rados = kwargs.get('rados', rados)
 

--- a/nova/virt/libvirt/utils.py
+++ b/nova/virt/libvirt/utils.py
@@ -639,8 +639,16 @@ def get_fs_info(path):
             'used': used}
 
 
-def fetch_image(context, target, image_id, user_id, project_id, max_size=0):
+def fetch_image(context, target, image_id, user_id, project_id, max_size=0,
+                backend_dest=None):
     """Grab image."""
+    if backend_dest:
+        try:
+            images.direct_fetch(context, image_id, backend_dest,
+                                user_id, project_id)
+            return
+        except exception.ImageUnacceptable:
+            LOG.debug(_('could not fetch directly, falling back to download'))
     images.fetch_to_raw(context, image_id, target, user_id, project_id,
                         max_size=max_size)
 

--- a/nova/virt/powervm/driver.py
+++ b/nova/virt/powervm/driver.py
@@ -92,9 +92,13 @@ class PowerVMDriver(driver.ComputeDriver):
 
     def plug_vifs(self, instance, network_info):
         """Plug VIFs into networks."""
-        LOG.debug(_('Network injection is not supported by the '
-                    'PowerVM driver.'), instance)
-        pass
+        msg = _("VIF plugging is not supported by the PowerVM driver.")
+        raise NotImplementedError(msg)
+
+    def unplug_vifs(self, instance, network_info):
+        """Unplug VIFs from networks."""
+        msg = _("VIF unplugging is not supported by the PowerVM driver.")
+        raise NotImplementedError(msg)
 
     def macs_for_instance(self, instance):
         return self._powervm.macs_for_instance(instance)

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -372,14 +372,6 @@ class VMwareESXDriver(driver.ComputeDriver):
         """inject network info for specified instance."""
         self._vmops.inject_network_info(instance, network_info)
 
-    def plug_vifs(self, instance, network_info):
-        """Plug VIFs into networks."""
-        self._vmops.plug_vifs(instance, network_info)
-
-    def unplug_vifs(self, instance, network_info):
-        """Unplug VIFs from networks."""
-        self._vmops.unplug_vifs(instance, network_info)
-
     def list_instance_uuids(self):
         """List VM instance UUIDs."""
         uuids = self._vmops.list_instances()
@@ -732,16 +724,6 @@ class VMwareVCDriver(VMwareESXDriver):
         """inject network info for specified instance."""
         _vmops = self._get_vmops_for_compute_node(instance['node'])
         _vmops.inject_network_info(instance, network_info)
-
-    def plug_vifs(self, instance, network_info):
-        """Plug VIFs into networks."""
-        _vmops = self._get_vmops_for_compute_node(instance['node'])
-        _vmops.plug_vifs(instance, network_info)
-
-    def unplug_vifs(self, instance, network_info):
-        """Unplug VIFs from networks."""
-        _vmops = self._get_vmops_for_compute_node(instance['node'])
-        _vmops.unplug_vifs(instance, network_info)
 
 
 class VMwareAPISession(object):

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -57,11 +57,11 @@ def split_datastore_path(datastore_path):
     return datastore_url, path.strip()
 
 
-def get_vm_create_spec(client_factory, instance, data_store_name,
+def get_vm_create_spec(client_factory, instance, name, data_store_name,
                        vif_infos, os_type="otherGuest"):
     """Builds the VM Create spec."""
     config_spec = client_factory.create('ns0:VirtualMachineConfigSpec')
-    config_spec.name = instance['uuid']
+    config_spec.name = name
     config_spec.guestId = os_type
 
     # Allow nested ESX instances to host 64 bit VMs.
@@ -1043,13 +1043,14 @@ def get_vmdk_backed_disk_device(hardware_devices, uuid):
             return device
 
 
-def get_vmdk_volume_disk(hardware_devices):
+def get_vmdk_volume_disk(hardware_devices, path=None):
     if hardware_devices.__class__.__name__ == "ArrayOfVirtualDevice":
         hardware_devices = hardware_devices.VirtualDevice
 
     for device in hardware_devices:
         if (device.__class__.__name__ == "VirtualDisk"):
-            return device
+            if not path or path == device.backing.fileName:
+                return device
 
 
 def get_res_pool_ref(session, cluster, node_mo_id):

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -844,8 +844,6 @@ class VMwareVMOps(object):
     def reboot(self, instance, network_info):
         """Reboot a VM instance."""
         vm_ref = vm_util.get_vm_ref(self._session, instance)
-        self.plug_vifs(instance, network_info)
-
         lst_properties = ["summary.guest.toolsStatus", "runtime.powerState",
                           "summary.guest.toolsRunningStatus"]
         props = self._session._call_method(vim_util, "get_object_properties",
@@ -898,9 +896,6 @@ class VMwareVMOps(object):
             except Exception as excep:
                 LOG.warn(_("In vmwareapi:vmops:delete, got this exception"
                            " while destroying the VM: %s") % str(excep))
-
-            if network_info:
-                self.unplug_vifs(instance, network_info)
         except Exception as exc:
             LOG.exception(exc, instance=instance)
 
@@ -945,10 +940,6 @@ class VMwareVMOps(object):
             except Exception as excep:
                 LOG.warn(_("In vmwareapi:vmops:destroy, got this exception"
                            " while un-registering the VM: %s") % str(excep))
-
-            if network_info:
-                self.unplug_vifs(instance, network_info)
-
             # Delete the folder holding the VM related content on
             # the datastore.
             if destroy_disks:
@@ -1228,9 +1219,6 @@ class VMwareVMOps(object):
         except Exception as excep:
             LOG.warn(_("In vmwareapi:vmops:confirm_migration, got this "
                      "exception while destroying the VM: %s") % str(excep))
-
-        if network_info:
-            self.unplug_vifs(instance, network_info)
 
     def finish_revert_migration(self, instance, network_info,
                                 block_device_info, power_on=True):
@@ -1598,11 +1586,13 @@ class VMwareVMOps(object):
 
     def plug_vifs(self, instance, network_info):
         """Plug VIFs into networks."""
-        pass
+        msg = _("VIF plugging is not supported by the VMware driver.")
+        raise NotImplementedError(msg)
 
     def unplug_vifs(self, instance, network_info):
         """Unplug VIFs from networks."""
-        pass
+        msg = _("VIF unplugging is not supported by the VMware driver.")
+        raise NotImplementedError(msg)
 
 
 class VMwareVCVMOps(VMwareVMOps):

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -1584,16 +1584,6 @@ class VMwareVMOps(object):
         client_factory = self._session._get_vim().client.factory
         self._set_machine_id(client_factory, instance, network_info)
 
-    def plug_vifs(self, instance, network_info):
-        """Plug VIFs into networks."""
-        msg = _("VIF plugging is not supported by the VMware driver.")
-        raise NotImplementedError(msg)
-
-    def unplug_vifs(self, instance, network_info):
-        """Unplug VIFs from networks."""
-        msg = _("VIF unplugging is not supported by the VMware driver.")
-        raise NotImplementedError(msg)
-
 
 class VMwareVCVMOps(VMwareVMOps):
     """Management class for VM-related tasks.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = nova
-version = 2013.2.3
+version = 2013.2.4
 summary = Cloud computing fabric controller
 description-file =
     README.rst


### PR DESCRIPTION
This PR brings in Josh's rbd changes into our havana branch, addresses DE727 - Allows us to boot ephemeral instances on compute nodes with insufficient local storage by utilizing 'libvirt_images_type = rbd' . This, along with the appropriate inclusion of ceph configurations files/keyring achieves the same functionality as the old 'boot volume patch' we reverted.

Closes-rally-bug: DE727
Closes-rally-bug: DE642
Closes-bug: 1226351
