### PR TITLE
Fix test broken by early cherry pick of f087a6f

### DIFF
--- a/nova/tests/compute/test_compute_mgr.py
+++ b/nova/tests/compute/test_compute_mgr.py
@@ -1161,13 +1161,13 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             mock.patch.object(self.compute, '_get_instance_nw_info',
                                return_value=None),
             mock.patch.object(self.compute,
-                              '_get_instance_volume_block_device_info',
+                              '_get_instance_block_device_info',
                                return_value={}),
             mock.patch.object(self.compute, '_is_instance_storage_shared',
                                return_value=False),
             mock.patch.object(self.compute.driver, 'destroy')
         ) as (_get_instances_on_driver, _get_instance_nw_info,
-              _get_instance_volume_block_device_info,
+              _get_instance_block_device_info,
               _is_instance_storage_shared, destroy):
             self.compute._destroy_evacuated_instances(self.context)
             destroy.assert_called_once_with(self.context, instance_2, None,


### PR DESCRIPTION
f087a6f77ef was cherry picked to stable/icehouse but hadn't
landed yet when it was needed, so we pulled it in while
it still had only one +2 in Gerrit.  Unfortunately another
change was merged since then that causes problems: a unit test
fails because it needs a similar update to what was done in
f087a6f77ef (which will probably now need to be rebased
and have this patch applied before it can actually land upstream).

This patch makes a minor correction to a unit test that is inline
with f087a6f77ef to get tests passing again.

Related-Change-Id: Iec329d1c12a48ea90ba9d57decd0996fde6544f0
Closes-Bug: #1305423
Upstream-review: https://review.openstack.org/#/c/100362/
