### PR TITLE
Cherrypick RBD commits

### DIFF
--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -4145,8 +4145,8 @@ class ComputeManager(manager.SchedulerDependentManager):
         # No instance booting at source host, but instance dir
         # must be deleted for preparing next block migration
         # must be deleted for preparing next live migration w/o shared storage
-        is_shared_block_storage = False
-        is_shared_instance_path = False
+        is_shared_block_storage = True
+        is_shared_instance_path = True
         if migrate_data:
             is_shared_block_storage = migrate_data.get(
                     'is_shared_block_storage', True)
@@ -4155,7 +4155,8 @@ class ComputeManager(manager.SchedulerDependentManager):
 
         if block_migration or not is_shared_instance_path:
             self.driver.destroy(instance_ref, network_info,
-                    destroy_disks = not is_shared_block_storage)
+                    destroy_disks=not is_shared_block_storage,
+                    migrate_data=migrate_data)
         else:
             # self.driver.destroy() usually performs  vif unplugging
             # but we must do it explicitly here when block_migration
@@ -4285,9 +4286,10 @@ class ComputeManager(manager.SchedulerDependentManager):
                     'is_shared_block_storage', True)
             is_shared_instance_path = migrate_data.get(
                     'is_shared_instance_path', True)
-        if block_migration or (is_shared_block_storage and not is_shared_instance_path):
+        if block_migration or (
+                is_shared_block_storage and not is_shared_instance_path):
             self.compute_rpcapi.rollback_live_migration_at_destination(context,
-                    instance, dest, destroy_disks = not is_shared_block_storage)
+                    instance, dest, destroy_disks=not is_shared_block_storage)
 
         self._notify_about_instance_usage(context, instance,
                                           "live_migration._rollback.end")

--- a/nova/compute/rpcapi.py
+++ b/nova/compute/rpcapi.py
@@ -682,12 +682,13 @@ class ComputeAPI(rpcclient.RpcProxy):
                    instance=instance, migration=migration,
                    reservations=reservations)
 
-    def rollback_live_migration_at_destination(self, ctxt, instance, host):
+    def rollback_live_migration_at_destination(self, ctxt, instance, host,
+                                               destroy_disks=True):
         instance_p = jsonutils.to_primitive(instance)
         cctxt = self.client.prepare(server=host,
                 version=_get_version('2.0'))
         cctxt.cast(ctxt, 'rollback_live_migration_at_destination',
-                   instance=instance_p)
+                   instance=instance_p, destroy_disks=destroy_disks)
 
     def run_instance(self, ctxt, instance, host, request_spec,
                      filter_properties, requested_networks,

--- a/nova/image/glance.py
+++ b/nova/image/glance.py
@@ -295,7 +295,7 @@ class GlanceImageService(object):
         base_image_meta = self._translate_from_glance(image)
         return base_image_meta
 
-    def _get_locations(self, context, image_id):
+    def get_locations(self, context, image_id):
         """Returns the direct url representing the backend storage location,
         or None if this attribute is not shown by Glance.
         """
@@ -327,7 +327,7 @@ class GlanceImageService(object):
     def download(self, context, image_id, data=None, dst_path=None):
         """Calls out to Glance for data and writes data."""
         if CONF.allowed_direct_url_schemes and dst_path is not None:
-            locations = self._get_locations(context, image_id)
+            locations = self.get_locations(context, image_id)
             for entry in locations:
                 loc_url = entry['url']
                 loc_meta = entry['metadata']

--- a/nova/tests/compute/test_compute.py
+++ b/nova/tests/compute/test_compute.py
@@ -4438,7 +4438,7 @@ class ComputeTestCase(BaseTestCase):
         fake_notifier.NOTIFICATIONS = []
         # start test
         self.mox.ReplayAll()
-        migrate_data = {'is_shared_storage': False}
+        migrate_data = {'is_shared_instance_path': False}
         ret = self.compute.pre_live_migration(c, instance=instance,
                                               block_migration=False,
                                               migrate_data=migrate_data)
@@ -4500,7 +4500,7 @@ class ComputeTestCase(BaseTestCase):
         self.compute.compute_rpcapi.remove_volume_connection(
                 c, updated_instance, 'vol2-id', dest_host)
         self.compute.compute_rpcapi.rollback_live_migration_at_destination(
-                c, updated_instance, dest_host)
+                c, updated_instance, dest_host, destroy_disks=True)
 
         # start test
         self.mox.ReplayAll()
@@ -4520,7 +4520,7 @@ class ComputeTestCase(BaseTestCase):
 
         instance = jsonutils.to_primitive(instance_ref)
 
-        migrate_data = {'is_shared_storage': False}
+        migrate_data = {'is_shared_instance_path': False}
 
         self.mox.StubOutWithMock(self.compute.compute_rpcapi,
                                  'pre_live_migration')
@@ -4600,7 +4600,7 @@ class ComputeTestCase(BaseTestCase):
 
         # start test
         self.mox.ReplayAll()
-        migrate_data = {'is_shared_storage': False}
+        migrate_data = {'is_shared_instance_path': False}
         self.compute._post_live_migration(c, inst_ref, dest,
                                           migrate_data=migrate_data)
         self.assertTrue('destroyed' in result)

--- a/nova/tests/compute/test_rpcapi.py
+++ b/nova/tests/compute/test_rpcapi.py
@@ -340,7 +340,8 @@ class ComputeRpcAPITestCase(test.TestCase):
 
     def test_rollback_live_migration_at_destination(self):
         self._test_compute_api('rollback_live_migration_at_destination',
-                'cast', instance=self.fake_instance, host='host')
+                'cast', instance=self.fake_instance, host='host',
+                destroy_disks=True)
 
     def test_run_instance(self):
         self._test_compute_api('run_instance', 'cast',

--- a/nova/tests/virt/libvirt/fake_libvirt_utils.py
+++ b/nova/tests/virt/libvirt/fake_libvirt_utils.py
@@ -211,8 +211,10 @@ def pick_disk_driver_name(hypervisor_version, is_block_dev=False):
 
 
 def list_rbd_volumes(pool):
-    fake_volumes = ['fakeinstancename.local', 'fakeinstancename.swap',
-                    'fakeinstancename', 'wronginstancename']
+    fake_volumes = ['875a8070-d0b9-4949-8b31-104d125c9a64.local',
+                    '875a8070-d0b9-4949-8b31-104d125c9a64.swap',
+                    '875a8070-d0b9-4949-8b31-104d125c9a64',
+                    'wrong875a8070-d0b9-4949-8b31-104d125c9a64']
     return fake_volumes
 
 

--- a/nova/tests/virt/libvirt/fake_libvirt_utils.py
+++ b/nova/tests/virt/libvirt/fake_libvirt_utils.py
@@ -220,3 +220,7 @@ def list_rbd_volumes(pool):
 
 def remove_rbd_volumes(pool, *names):
     pass
+
+
+def ascii_str(s):
+    return libvirt_utils.ascii_str(s)

--- a/nova/tests/virt/libvirt/test_imagebackend.py
+++ b/nova/tests/virt/libvirt/test_imagebackend.py
@@ -736,10 +736,12 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
         self.libvirt_utils = imagebackend.libvirt_utils
         self.utils = imagebackend.utils
         self.rbd = self.mox.CreateMockAnything()
+        self.rados = self.mox.CreateMockAnything()
 
     def prepare_mocks(self):
         fn = self.mox.CreateMockAnything()
         self.mox.StubOutWithMock(imagebackend, 'rbd')
+        self.mox.StubOutWithMock(imagebackend, 'rados')
         return fn
 
     def test_cache(self):
@@ -830,6 +832,9 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
 
         self.rbd.RBD_FEATURE_LAYERING = 1
 
+        self.mox.StubOutWithMock(imagebackend.disk, 'get_disk_size')
+        imagebackend.disk.get_disk_size(self.TEMPLATE_PATH
+                                       ).AndReturn(self.SIZE)
         rbd_name = "%s/%s" % (self.INSTANCE['name'], self.NAME)
         cmd = ('--pool', self.POOL, self.TEMPLATE_PATH,
                rbd_name, '--new-format', '--id', self.USER,
@@ -848,9 +853,13 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
         fake_processutils.fake_execute_clear_log()
         fake_processutils.stub_out_processutils_execute(self.stubs)
         self.mox.StubOutWithMock(imagebackend, 'rbd')
+        self.mox.StubOutWithMock(imagebackend, 'rados')
         image = self.image_class(self.INSTANCE, self.NAME)
 
         def fake_fetch(target, *args, **kwargs):
+            return
+
+        def fake_resize(rbd_name, size):
             return
 
         self.stubs.Set(os.path, 'exists', lambda _: True)

--- a/nova/tests/virt/libvirt/test_imagebackend.py
+++ b/nova/tests/virt/libvirt/test_imagebackend.py
@@ -977,6 +977,21 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
 
         self.assertFalse(image._is_cloneable(location))
 
+    def test_image_path(self):
+
+        conf = "FakeConf"
+        pool = "FakePool"
+        user = "FakeUser"
+
+        self.flags(libvirt_images_rbd_pool=pool)
+        self.flags(libvirt_images_rbd_ceph_conf=conf)
+        self.flags(rbd_user=user)
+        image = self.image_class(self.INSTANCE, self.NAME)
+        rbd_path = "rbd:%s/%s:id=%s:conf=%s" % (pool, image.rbd_name,
+                                                user, conf)
+
+        self.assertEqual(image.path, rbd_path)
+
 
 class BackendTestCase(test.NoDBTestCase):
     INSTANCE = {'name': 'fake-instance',

--- a/nova/tests/virt/libvirt/test_imagebackend.py
+++ b/nova/tests/virt/libvirt/test_imagebackend.py
@@ -402,14 +402,14 @@ class Qcow2TestCase(_ImageTestCase, test.NoDBTestCase):
     def test_create_image_too_small(self):
         fn = self.prepare_mocks()
         self.mox.StubOutWithMock(os.path, 'exists')
-        self.mox.StubOutWithMock(imagebackend.disk, 'get_disk_size')
+        self.mox.StubOutWithMock(imagebackend.Qcow2, 'get_disk_size')
         if self.OLD_STYLE_INSTANCE_PATH:
             os.path.exists(self.OLD_STYLE_INSTANCE_PATH).AndReturn(False)
         os.path.exists(self.DISK_INFO_PATH).AndReturn(False)
         os.path.exists(self.INSTANCES_PATH).AndReturn(True)
         os.path.exists(self.TEMPLATE_PATH).AndReturn(True)
-        imagebackend.disk.get_disk_size(self.TEMPLATE_PATH
-                                       ).AndReturn(self.SIZE)
+        imagebackend.Qcow2.get_disk_size(self.TEMPLATE_PATH
+                                         ).AndReturn(self.SIZE)
         self.mox.ReplayAll()
 
         image = self.image_class(self.INSTANCE, self.NAME)

--- a/nova/tests/virt/libvirt/test_imagebackend.py
+++ b/nova/tests/virt/libvirt/test_imagebackend.py
@@ -832,9 +832,6 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
 
         self.rbd.RBD_FEATURE_LAYERING = 1
 
-        self.mox.StubOutWithMock(imagebackend.disk, 'get_disk_size')
-        imagebackend.disk.get_disk_size(self.TEMPLATE_PATH
-                                       ).AndReturn(self.SIZE)
         rbd_name = "%s/%s" % (self.INSTANCE['name'], self.NAME)
         cmd = ('--pool', self.POOL, self.TEMPLATE_PATH,
                rbd_name, '--new-format', '--id', self.USER,
@@ -872,6 +869,113 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
     def test_parent_compatible(self):
         self.assertEqual(getargspec(imagebackend.Image.libvirt_info),
              getargspec(self.image_class.libvirt_info))
+
+    def test_direct_fetch(self):
+        self.prepare_mocks()
+        self.rbd.RBD_FEATURE_LAYERING = 1
+
+        image = self.image_class(self.INSTANCE, self.NAME)
+        self.mox.StubOutWithMock(image, '_clone')
+        image._clone('b', 'c', 'd')
+        self.mox.ReplayAll()
+
+        def fake_parse_location(url):
+            return 'a', 'b', 'c', 'd'
+
+        self.stubs.Set(image, 'check_image_exists', lambda: False)
+        self.stubs.Set(image, '_is_cloneable', lambda x: True)
+        self.stubs.Set(image, '_parse_location', fake_parse_location)
+
+        image.direct_fetch('image_id',
+                           {'disk_format': 'raw'},
+                           [{'url': 'rbd://a/b/c/d'}])
+
+        self.mox.VerifyAll()
+
+    def test_direct_fetch_fail(self):
+        image = self.image_class(self.INSTANCE, self.NAME)
+        self.stubs.Set(image, '_is_cloneable', lambda: True)
+        self.assertRaises(exception.ImageUnacceptable,
+                          image.direct_fetch, 'image_id',
+                          {'disk_format': 'raw'},
+                          [{'url': 'rbd://a/b/c/d'}])
+        self.rbd.RBD_FEATURE_LAYERING = 1
+        self.assertRaises(exception.ImageUnacceptable,
+                          image.direct_fetch, 'image_id',
+                          {},
+                          [{'url': 'rbd://a/b/c/d'}])
+        self.assertRaises(exception.ImageUnacceptable,
+                          image.direct_fetch, 'image_id',
+                          {'disk_format': 'raw'},
+                          [])
+        self.stubs.Set(image, '_is_cloneable', lambda: False)
+        self.assertRaises(exception.ImageUnacceptable,
+                          image.direct_fetch, 'image_id',
+                          {'disk_format': 'raw'},
+                          [{'url': 'rbd://a/b/c/d'}])
+
+    def test_good_locations(self):
+        image = self.image_class(self.INSTANCE, self.NAME)
+        locations = ['rbd://fsid/pool/image/snap',
+                     'rbd://%2F/%2F/%2F/%2F', ]
+        map(image._parse_location, locations)
+
+    def test_bad_locations(self):
+        image = self.image_class(self.INSTANCE, self.NAME)
+        locations = ['rbd://image',
+                     'http://path/to/somewhere/else',
+                     'rbd://image/extra',
+                     'rbd://image/',
+                     'rbd://fsid/pool/image/',
+                     'rbd://fsid/pool/image/snap/',
+                     'rbd://///', ]
+        for loc in locations:
+            self.assertRaises(exception.ImageUnacceptable,
+                              image._parse_location,
+                              loc)
+            self.assertFalse(image._is_cloneable(loc))
+
+    def test_cloneable(self):
+        image = self.image_class(self.INSTANCE, self.NAME)
+        self.stubs.Set(image, '_get_fsid', lambda: 'abc')
+        location = u'rbd://abc/pool/image/snap'
+        mock_proxy = self.mox.CreateMockAnything()
+        self.mox.StubOutWithMock(imagebackend, 'RBDVolumeProxy')
+
+        imagebackend.RBDVolumeProxy(image, 'image',
+                                    pool='pool',
+                                    snapshot='snap',
+                                    read_only=True).AndReturn(mock_proxy)
+        mock_proxy.__enter__().AndReturn(mock_proxy)
+        mock_proxy.__exit__(None, None, None).AndReturn(None)
+
+        self.mox.ReplayAll()
+
+        self.assertTrue(image._is_cloneable(location))
+
+    def test_uncloneable_different_fsid(self):
+        image = self.image_class(self.INSTANCE, self.NAME)
+        self.stubs.Set(image, '_get_fsid', lambda: 'abc')
+        location = 'rbd://def/pool/image/snap'
+        self.assertFalse(image._is_cloneable(location))
+
+    def test_uncloneable_unreadable(self):
+        self.prepare_mocks()
+        image = self.image_class(self.INSTANCE, self.NAME, rbd=self.rbd)
+        self.stubs.Set(image, '_get_fsid', lambda: 'abc')
+        location = 'rbd://abc/pool/image/snap'
+        self.stubs.Set(self.rbd, 'Error', test.TestingException)
+        self.mox.StubOutWithMock(imagebackend, 'RBDVolumeProxy')
+
+        imagebackend.RBDVolumeProxy(image, 'image',
+                                    pool='pool',
+                                    snapshot='snap',
+                                    read_only=True).AndRaise(
+            test.TestingException)
+
+        self.mox.ReplayAll()
+
+        self.assertFalse(image._is_cloneable(location))
 
 
 class BackendTestCase(test.NoDBTestCase):

--- a/nova/tests/virt/libvirt/test_libvirt.py
+++ b/nova/tests/virt/libvirt/test_libvirt.py
@@ -4369,8 +4369,10 @@ class LibvirtConnTestCase(test.TestCase):
         def fake_get_info(instance_name):
             return {'state': power_state.SHUTDOWN, 'id': -1}
 
-        fake_volumes = ['fakeinstancename.local', 'fakeinstancename.swap',
-                        'fakeinstancename', 'wronginstancename']
+        fake_volumes = ['875a8070-d0b9-4949-8b31-104d125c9a64.local',
+                        '875a8070-d0b9-4949-8b31-104d125c9a64.swap',
+                        '875a8070-d0b9-4949-8b31-104d125c9a64',
+                        'wrong875a8070-d0b9-4949-8b31-104d125c9a64']
         fake_pool = 'fake_pool'
         fake_instance = {'name': 'fakeinstancename', 'id': 'instanceid',
                          'uuid': '875a8070-d0b9-4949-8b31-104d125c9a64'}

--- a/nova/tests/virt/libvirt/test_libvirt.py
+++ b/nova/tests/virt/libvirt/test_libvirt.py
@@ -2906,7 +2906,7 @@ class LibvirtConnTestCase(test.TestCase):
         ret = conn.check_can_live_migrate_source(self.context, instance_ref,
                                                  dest_check_data)
         self.assertTrue(type(ret) == dict)
-        self.assertTrue('is_shared_storage' in ret)
+        self.assertTrue('is_shared_instance_path' in ret)
 
     def test_check_can_live_migrate_source_vol_backed_w_disk_raises(self):
         instance_ref = db.instance_create(self.context, self.test_instance)
@@ -3198,7 +3198,7 @@ class LibvirtConnTestCase(test.TestCase):
             self.mox.StubOutWithMock(conn, 'plug_vifs')
             conn.plug_vifs(mox.IsA(inst_ref), nw_info)
             self.mox.ReplayAll()
-            migrate_data = {'is_shared_storage': False,
+            migrate_data = {'is_shared_instance_path': False,
                             'is_volume_backed': True,
                             'block_migration': False,
                             'instance_relative_path': inst_ref['name']

--- a/nova/virt/driver.py
+++ b/nova/virt/driver.py
@@ -242,7 +242,7 @@ class ComputeDriver(object):
         raise NotImplementedError()
 
     def destroy(self, instance, network_info, block_device_info=None,
-                destroy_disks=True):
+                destroy_disks=True, migrate_data=None):
         """Destroy (shutdown and delete) the specified instance.
 
         If the instance is not found (for example if networking failed), this

--- a/nova/virt/fake.py
+++ b/nova/virt/fake.py
@@ -207,7 +207,7 @@ class FakeDriver(driver.ComputeDriver):
         pass
 
     def destroy(self, instance, network_info, block_device_info=None,
-                destroy_disks=True, context=None):
+                destroy_disks=True, context=None, migrate_data=None):
         key = instance['name']
         if key in self.instances:
             del self.instances[key]

--- a/nova/virt/images.py
+++ b/nova/virt/images.py
@@ -179,6 +179,26 @@ def convert_image(source, dest, out_format, run_as_root=False):
     utils.execute(*cmd, run_as_root=run_as_root)
 
 
+def direct_fetch(context, image_href, backend_dest, _user_id, _project_id,
+                 max_size=0):
+    """Allow an image backend to fetch directly from the glance backend.
+
+    :backend_dest: the image backend, which must have a direct_fetch
+                   method accepting a list of image locations. This method
+                   should raise exceptions.ImageUnacceptable if the image
+                   cannot be downloaded directly.
+    """
+    # TODO(jdurgin): improve auth handling as noted in fetch()
+    image_service, image_id = glance.get_remote_image_service(context,
+                                                              image_href)
+    locations = image_service.get_locations(context, image_id)
+    image_meta = image_service.show(context, image_id)
+
+    LOG.debug(_('Image locations are: %(locs)s') % {'locs': locations})
+    backend_dest.direct_fetch(image_id, image_meta, locations,
+                              max_size=max_size)
+
+
 def fetch(context, image_href, path, _user_id, _project_id, max_size=0):
     # TODO(vish): Improve context handling and add owner and auth data
     #             when it is added to glance.  Right now there is no

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -952,7 +952,7 @@ class LibvirtDriver(driver.ComputeDriver):
     def _cleanup_rbd(self, instance):
         pool = CONF.libvirt_images_rbd_pool
         volumes = libvirt_utils.list_rbd_volumes(pool)
-        pattern = instance['name']
+        pattern = instance['uuid']
 
         def belongs_to_instance(disk):
             return disk.startswith(pattern)

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -2380,13 +2380,15 @@ class LibvirtDriver(driver.ComputeDriver):
             if size == 0 or suffix == '.rescue':
                 size = None
 
-            image('disk').cache(fetch_func=libvirt_utils.fetch_image,
-                                context=context,
-                                filename=root_fname,
-                                size=size,
-                                image_id=disk_images['image_id'],
-                                user_id=instance['user_id'],
-                                project_id=instance['project_id'])
+            disk_image = image('disk')
+            disk_image.cache(fetch_func=libvirt_utils.fetch_image,
+                             context=context,
+                             filename=root_fname,
+                             size=size,
+                             backend_dest=disk_image,
+                             image_id=disk_images['image_id'],
+                             user_id=instance['user_id'],
+                             project_id=instance['project_id'])
 
         # Lookup the filesystem type if required
         os_type_with_default = disk.get_fs_type_for_os_type(

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -72,6 +72,8 @@ CONF = cfg.CONF
 CONF.register_opts(__imagebackend_opts)
 CONF.import_opt('base_dir_name', 'nova.virt.libvirt.imagecache')
 CONF.import_opt('preallocate_images', 'nova.virt.driver')
+CONF.import_opt('rbd_user', 'nova.virt.libvirt.volume')
+CONF.import_opt('rbd_secret_uuid', 'nova.virt.libvirt.volume')
 
 LOG = logging.getLogger(__name__)
 

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -594,6 +594,12 @@ class Rbd(Image):
         self.rbd = kwargs.get('rbd', rbd)
         self.rados = kwargs.get('rados', rados)
 
+        self.path = 'rbd:%s/%s' % (self.pool, self.rbd_name)
+        if self.rbd_user:
+            self.path += ':id=' + self.rbd_user
+        if self.ceph_conf:
+            self.path += ':conf=' + self.ceph_conf
+
     def _connect_to_rados(self, pool=None):
         client = self.rados.Rados(rados_id=self.rbd_user,
                                   conffile=self.ceph_conf)
@@ -726,8 +732,7 @@ class Rbd(Image):
         pass
 
     def snapshot_extract(self, target, out_format):
-        snap = 'rbd:%s/%s' % (self.pool, self.rbd_name)
-        images.convert_image(snap, target, out_format)
+        images.convert_image(self.path, target, out_format)
 
     def snapshot_delete(self):
         pass

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -659,7 +659,7 @@ class Rbd(Image):
         info = vconfig.LibvirtConfigGuestDisk()
 
         hosts, ports = self._get_mon_addrs()
-        info.device_type = device_type
+        info.source_device = device_type
         info.driver_format = 'raw'
         info.driver_cache = cache_mode
         info.target_bus = disk_bus
@@ -794,7 +794,7 @@ class Rbd(Image):
     def direct_fetch(self, image_id, image_meta, image_locations, max_size=0):
         if self.check_image_exists():
             return
-        if image_meta.get('disk_format') != 'raw':
+        if image_meta.get('disk_format') not in ['raw', 'iso']:
             reason = _('Image is not raw format')
             raise exception.ImageUnacceptable(image_id=image_id, reason=reason)
         if not self._supports_layering():

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -301,7 +301,7 @@ class Image(object):
             raise exception.DiskInfoReadWriteFail(reason=unicode(e))
         return driver_format
 
-    def direct_fetch(self, image_id, image_meta, image_locations):
+    def direct_fetch(self, image_id, image_meta, image_locations, max_size=0):
         """Create an image from a direct image location.
 
         :raises: exception.ImageUnacceptable if it cannot be fetched directly
@@ -793,7 +793,7 @@ class Rbd(Image):
                                      self.rbd_name,
                                      features=self.rbd.RBD_FEATURE_LAYERING)
 
-    def direct_fetch(self, image_id, image_meta, image_locations):
+    def direct_fetch(self, image_id, image_meta, image_locations, max_size=0):
         if self.check_image_exists():
             return
         if image_meta.get('disk_format') != 'raw':

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -201,8 +201,7 @@ class Image(object):
                           (CONF.preallocate_images, self.path))
         return can_fallocate
 
-    @staticmethod
-    def verify_base_size(base, size, base_size=0):
+    def verify_base_size(self, base, size, base_size=0):
         """Check that the base image is not larger than size.
            Since images can't be generally shrunk, enforce this
            constraint taking account of virtual image size.
@@ -221,7 +220,7 @@ class Image(object):
             return
 
         if size and not base_size:
-            base_size = disk.get_disk_size(base)
+            base_size = self.get_disk_size(base)
 
         if size < base_size:
             msg = _('%(base)s virtual size %(base_size)s '
@@ -230,6 +229,9 @@ class Image(object):
                               'base_size': base_size,
                               'size': size})
             raise exception.InstanceTypeDiskTooSmall()
+
+    def get_disk_size(self, name):
+        disk.get_disk_size(name)
 
     def snapshot_create(self):
         raise NotImplementedError()
@@ -695,7 +697,10 @@ class Rbd(Image):
             vol.resize(int(size))
 
     def _size(self):
-        with RBDVolumeProxy(self, self.rbd_name) as vol:
+        return self.get_disk_size(self.rbd_name)
+
+    def get_disk_size(self, name):
+        with RBDVolumeProxy(self, name) as vol:
             return vol.size()
 
     def create_image(self, prepare_template, base, size, *args, **kwargs):

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -534,7 +534,8 @@ class RBDVolumeProxy(object):
         client, ioctx = driver._connect_to_rados(pool)
         try:
             self.volume = driver.rbd.Image(ioctx, str(name),
-                                           snapshot=ascii_str(snapshot),
+                                           snapshot=libvirt_utils.ascii_str(
+                                                        snapshot),
                                            read_only=read_only)
         except driver.rbd.Error:
             LOG.exception(_("error opening rbd image %s"), name)
@@ -570,17 +571,6 @@ class RADOSClient(object):
         self.driver._disconnect_from_rados(self.cluster, self.ioctx)
 
 
-def ascii_str(s):
-    """Convert a string to ascii, or return None if the input is None.
-
-    This is useful when a parameter is None by default, or a string. LibRBD
-    only accepts ascii, hence the need for conversion.
-    """
-    if s is None:
-        return s
-    return str(s)
-
-
 class Rbd(Image):
     def __init__(self, instance=None, disk_name=None, path=None,
                  snapshot_name=None, **kwargs):
@@ -598,8 +588,9 @@ class Rbd(Image):
                                  ' libvirt_images_rbd_pool'
                                  ' flag to use rbd images.'))
         self.pool = str(CONF.libvirt_images_rbd_pool)
-        self.ceph_conf = ascii_str(CONF.libvirt_images_rbd_ceph_conf)
-        self.rbd_user = ascii_str(CONF.rbd_user)
+        self.ceph_conf = libvirt_utils.ascii_str(
+                         CONF.libvirt_images_rbd_ceph_conf)
+        self.rbd_user = libvirt_utils.ascii_str(CONF.rbd_user)
         self.rbd = kwargs.get('rbd', rbd)
         self.rados = kwargs.get('rados', rados)
 

--- a/nova/virt/libvirt/utils.py
+++ b/nova/virt/libvirt/utils.py
@@ -639,8 +639,16 @@ def get_fs_info(path):
             'used': used}
 
 
-def fetch_image(context, target, image_id, user_id, project_id, max_size=0):
+def fetch_image(context, target, image_id, user_id, project_id, max_size=0,
+                backend_dest=None):
     """Grab image."""
+    if backend_dest:
+        try:
+            images.direct_fetch(context, image_id, backend_dest,
+                                user_id, project_id)
+            return
+        except exception.ImageUnacceptable:
+            LOG.debug(_('could not fetch directly, falling back to download'))
     images.fetch_to_raw(context, image_id, target, user_id, project_id,
                         max_size=max_size)
 


### PR DESCRIPTION
This PR brings in Josh's rbd changes into our havana branch, addresses DE727 - Allows us to boot ephemeral instances on compute nodes with insufficient local storage by utilizing 'libvirt_images_type = rbd' . This, along with the appropriate inclusion of ceph configurations files/keyring achieves the same functionality as the old 'boot volume patch' we reverted.

Closes-rally-bug: DE727
Closes-rally-bug: DE642
Closes-bug: 1226351
