### PR TITLE
Network: ensure that ports are 'unset' when instance is deleted

### DIFF
--- a/nova/network/neutronv2/api.py
+++ b/nova/network/neutronv2/api.py
@@ -410,6 +410,15 @@ class API(base.Base):
         requested_networks = kwargs.get('requested_networks') or {}
         ports_to_skip = [port_id for nets, fips, port_id in requested_networks]
         ports = set(ports) - set(ports_to_skip)
+        # Reset device_id and device_owner for the ports that are skipped
+        for port in ports_to_skip:
+            port_req_body = {'port': {'device_id': '', 'device_owner': ''}}
+            try:
+                neutronv2.get_client(context).update_port(port,
+                                                          port_req_body)
+            except Exception:
+                LOG.info(_('Unable to reset device ID for port %s'), port,
+                         instance=instance)
 
         for port in ports:
             try:

--- a/nova/tests/network/test_neutronv2.py
+++ b/nova/tests/network/test_neutronv2.py
@@ -875,18 +875,44 @@ class TestNeutronv2(TestNeutronv2Base):
                           api.allocate_for_instance, self.context,
                           self.instance, requested_networks=requested_networks)
 
-    def _deallocate_for_instance(self, number):
+    def _deallocate_for_instance(self, number, requested_networks=None):
+        api = neutronapi.API()
         port_data = number == 1 and self.port_data1 or self.port_data2
+        ret_data = copy.deepcopy(port_data)
+        if requested_networks:
+            for net, fip, port in requested_networks:
+                ret_data.append({'network_id': net,
+                                 'device_id': self.instance['uuid'],
+                                 'device_owner': 'compute:nova',
+                                 'id': port,
+                                 'status': 'DOWN',
+                                 'admin_state_up': True,
+                                 'fixed_ips': [],
+                                 'mac_address': 'fake_mac', })
         self.moxed_client.list_ports(
             device_id=self.instance['uuid']).AndReturn(
-                {'ports': port_data})
+                {'ports': ret_data})
+        if requested_networks:
+            for net, fip, port in requested_networks:
+                self.moxed_client.update_port(port)
         for port in reversed(port_data):
             self.moxed_client.delete_port(port['id'])
 
         self.mox.ReplayAll()
 
         api = neutronapi.API()
-        api.deallocate_for_instance(self.context, self.instance)
+        api.deallocate_for_instance(self.context, self.instance,
+                                    requested_networks=requested_networks)
+
+    def test_deallocate_for_instance_1_with_requested(self):
+        requested = [('fake-net', 'fake-fip', 'fake-port')]
+        # Test to deallocate in one port env.
+        self._deallocate_for_instance(1, requested_networks=requested)
+
+    def test_deallocate_for_instance_2_with_requested(self):
+        requested = [('fake-net', 'fake-fip', 'fake-port')]
+        # Test to deallocate in one port env.
+        self._deallocate_for_instance(2, requested_networks=requested)
 
     def test_deallocate_for_instance_1(self):
         # Test to deallocate in one port env.


### PR DESCRIPTION
Commit a141206e9dfd31955b9b31d9e5a7f73bbd8510ca ensured that user defined
ports were not deleted when an instance is deleted or rescheduled. The
problem with this commit is that it did not reset the 'device_id' and
'device_owner' of the port. This leads to port leakage and eventually a tenant
is unable to launch any instances as their port quota has exceeded the
allocated amount.

The solution is for the deallocation to reset the 'device_id' and the
'device_owner' of the port. This is allocated when the port is actually assigned
to an instance.

In the case of minesweeper (which runs on OpenStack), the tenant was leaking ports.
The root cause was that the user defined ports were assigned to a specific instance,
which was deleted, as a result of a failed reschedule (which is legitimate).

When an instance is deleted all artificats of that instance should be reset on the
port.

Change-Id: Ie1516c299ce6d79faf2d5103a14d6d8931d3ede2
Closes-bug: #1321381
(cherry picked from commit 803d59e9f409a59403b2ce55040acc02e14eee28)

Conflicts:
    nova/tests/network/test_neutronv2.py
