### PR TITLE
enable cloning for rbd-backed ephemeral disks

### DIFF
--- a/nova/tests/virt/libvirt/test_imagehandler.py
+++ b/nova/tests/virt/libvirt/test_imagehandler.py
@@ -1,0 +1,136 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import mock
+
+from nova import test
+from nova.virt.libvirt import imagehandler
+
+
+IMAGE_ID = '155d900f-4e14-4e4c-a73d-069cbf4541e6'
+IMAGE_PATH = '/var/run/instances/_base/img'
+
+
+class RBDTestCase(test.NoDBTestCase):
+
+    def setUp(self):
+        super(RBDTestCase, self).setUp()
+        self.imagehandler = imagehandler.RBDCloneImageHandler(
+            rbd=mock.Mock(),
+            rados=mock.Mock())
+        self.imagehandler.driver.is_cloneable = mock.Mock()
+        self.imagehandler.driver.clone = mock.Mock()
+
+    def tearDown(self):
+        super(RBDTestCase, self).tearDown()
+
+    def test_fetch_image_no_snapshot(self):
+        url = 'rbd://old_image'
+        self.imagehandler.driver.is_cloneable.return_value = False
+        handled = self.imagehandler._fetch_image(None, IMAGE_ID,
+                                                 dict(disk_format='raw'),
+                                                 IMAGE_PATH,
+                                                 backend_type='rbd',
+                                                 backend_location=('a', 'b'),
+                                                 location=dict(url=url))
+        self.assertFalse(handled)
+        self.imagehandler.driver.is_cloneable.assert_called_once_with(url,
+                                                                      mock.ANY)
+        self.assertFalse(self.imagehandler.driver.clone.called)
+
+    def test_fetch_image_non_rbd_backend(self):
+        url = 'rbd://fsid/pool/image/snap'
+        self.imagehandler.driver.is_cloneable.return_value = True
+        handled = self.imagehandler._fetch_image(None, IMAGE_ID,
+                                                 dict(disk_format='raw'),
+                                                 IMAGE_PATH,
+                                                 backend_type='lvm',
+                                                 backend_location='/path',
+                                                 location=dict(url=url))
+        self.assertFalse(handled)
+        self.assertFalse(self.imagehandler.driver.clone.called)
+
+    def test_fetch_image_rbd_not_cloneable(self):
+        url = 'rbd://fsid/pool/image/snap'
+        dest_pool = 'foo'
+        dest_image = 'bar'
+        self.imagehandler.driver.is_cloneable.return_value = False
+        handled = self.imagehandler._fetch_image(None, IMAGE_ID,
+                                                 dict(disk_format='raw'),
+                                                 IMAGE_PATH,
+                                                 backend_type='rbd',
+                                                 backend_location=(dest_pool,
+                                                                   dest_image),
+                                                 location=dict(url=url))
+        self.imagehandler.driver.is_cloneable.assert_called_once_with(url,
+                                                                      mock.ANY)
+        self.assertFalse(handled)
+
+    def test_fetch_image_cloneable(self):
+        url = 'rbd://fsid/pool/image/snap'
+        dest_pool = 'foo'
+        dest_image = 'bar'
+        self.imagehandler.driver.is_cloneable.return_value = True
+        handled = self.imagehandler._fetch_image(None, IMAGE_ID,
+                                                 dict(disk_format='raw'),
+                                                 IMAGE_PATH,
+                                                 backend_type='rbd',
+                                                 backend_location=(dest_pool,
+                                                                   dest_image),
+                                                 location=dict(url=url))
+        self.imagehandler.driver.is_cloneable.assert_called_once_with(url,
+                                                                      mock.ANY)
+        self.imagehandler.driver.clone.assert_called_once_with(dest_pool,
+                                                               dest_image,
+                                                               'pool',
+                                                               'image',
+                                                               'snap')
+        self.assertTrue(handled)
+
+    def test_remove_image(self):
+        url = 'rbd://fsid/pool/image/snap'
+        pool = 'foo'
+        image = 'bar'
+        self.imagehandler.driver.remove = mock.Mock()
+        self.imagehandler.driver.is_cloneable.return_value = True
+        handled = self.imagehandler._remove_image(None, IMAGE_ID,
+                                                  dict(disk_format='raw'),
+                                                  IMAGE_PATH,
+                                                  backend_type='rbd',
+                                                  backend_location=(pool,
+                                                                    image),
+                                                  backend_dest='baz',
+                                                  location=dict(url=url))
+        self.imagehandler.driver.is_cloneable.assert_called_once_with(url,
+                                                                      mock.ANY)
+        self.imagehandler.driver.remove.assert_called_once_with(image)
+        self.assertTrue(handled)
+
+    def test_move_image(self):
+        url = 'rbd://fsid/pool/image/snap'
+        pool = 'foo'
+        image = 'bar'
+        dest_image = 'baz'
+        self.imagehandler.driver.rename = mock.Mock()
+        self.imagehandler.driver.is_cloneable.return_value = True
+        handled = self.imagehandler._move_image(None, IMAGE_ID,
+                                                dict(disk_format='raw'),
+                                                IMAGE_PATH, IMAGE_PATH,
+                                                backend_type='rbd',
+                                                backend_location=(pool, image),
+                                                backend_dest='baz',
+                                                location=dict(url=url))
+        self.imagehandler.driver.is_cloneable.assert_called_once_with(url,
+                                                                      mock.ANY)
+        self.imagehandler.driver.rename.assert_called_once_with(image,
+                                                                dest_image)
+        self.assertTrue(handled)

--- a/nova/tests/virt/libvirt/test_rbd_utils.py
+++ b/nova/tests/virt/libvirt/test_rbd_utils.py
@@ -1,0 +1,270 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+import mock
+
+from nova import exception
+from nova.openstack.common import log as logging
+from nova import test
+from nova import utils
+from nova.virt.libvirt import rbd_utils
+
+
+LOG = logging.getLogger(__name__)
+
+
+CEPH_MON_DUMP = """dumped monmap epoch 1
+{ "epoch": 1,
+  "fsid": "33630410-6d93-4d66-8e42-3b953cf194aa",
+  "modified": "2013-05-22 17:44:56.343618",
+  "created": "2013-05-22 17:44:56.343618",
+  "mons": [
+        { "rank": 0,
+          "name": "a",
+          "addr": "[::1]:6789\/0"},
+        { "rank": 1,
+          "name": "b",
+          "addr": "[::1]:6790\/0"},
+        { "rank": 2,
+          "name": "c",
+          "addr": "[::1]:6791\/0"},
+        { "rank": 3,
+          "name": "d",
+          "addr": "127.0.0.1:6792\/0"},
+        { "rank": 4,
+          "name": "e",
+          "addr": "example.com:6791\/0"}],
+  "quorum": [
+        0,
+        1,
+        2]}
+"""
+
+
+class RBDTestCase(test.NoDBTestCase):
+
+    def setUp(self):
+        super(RBDTestCase, self).setUp()
+
+        self.mock_rbd = mock.Mock()
+        self.mock_rados = mock.Mock()
+        self.mock_rados.Rados = mock.Mock
+        self.mock_rados.Rados.ioctx = mock.Mock()
+
+        self.mock_rbd.RBD = mock.Mock
+        self.mock_rbd.Image = mock.Mock
+        self.mock_rbd.Image.close = mock.Mock()
+        self.mock_rbd.RBD.Error = Exception
+        self.mock_rados.Error = Exception
+
+        self.rbd_pool = 'rbd'
+        self.driver = rbd_utils.RBDDriver(self.rbd_pool, None, None,
+                                          rbd_lib=self.mock_rbd,
+                                          rados_lib=self.mock_rados)
+
+        self.volume_name = u'volume-00000001'
+
+    def tearDown(self):
+        super(RBDTestCase, self).tearDown()
+
+    def test_good_locations(self):
+        locations = ['rbd://fsid/pool/image/snap',
+                     'rbd://%2F/%2F/%2F/%2F', ]
+        map(self.driver.parse_location, locations)
+
+    def test_bad_locations(self):
+        locations = ['rbd://image',
+                     'http://path/to/somewhere/else',
+                     'rbd://image/extra',
+                     'rbd://image/',
+                     'rbd://fsid/pool/image/',
+                     'rbd://fsid/pool/image/snap/',
+                     'rbd://///', ]
+        for loc in locations:
+            self.assertRaises(exception.ImageUnacceptable,
+                              self.driver.parse_location,
+                              loc)
+            self.assertFalse(
+                self.driver.is_cloneable(loc, {'disk_format': 'raw'}))
+
+    def test_cloneable(self):
+        with mock.patch.object(self.driver, '_get_fsid') as mock_get_fsid:
+            mock_get_fsid.return_value = 'abc'
+            location = 'rbd://abc/pool/image/snap'
+            info = {'disk_format': 'raw'}
+            self.assertTrue(self.driver.is_cloneable(location, info))
+            self.assertTrue(mock_get_fsid.called)
+
+    def test_uncloneable_different_fsid(self):
+        with mock.patch.object(self.driver, '_get_fsid') as mock_get_fsid:
+            mock_get_fsid.return_value = 'abc'
+            location = 'rbd://def/pool/image/snap'
+            self.assertFalse(
+                self.driver.is_cloneable(location, {'disk_format': 'raw'}))
+            self.assertTrue(mock_get_fsid.called)
+
+    @mock.patch.object(rbd_utils, 'RBDVolumeProxy')
+    def test_uncloneable_unreadable(self, mock_proxy):
+        with mock.patch.object(self.driver, '_get_fsid') as mock_get_fsid:
+            mock_get_fsid.return_value = 'abc'
+            location = 'rbd://abc/pool/image/snap'
+
+            mock_proxy.side_effect = self.mock_rbd.Error
+
+            args = [location, {'disk_format': 'raw'}]
+            self.assertFalse(self.driver.is_cloneable(*args))
+            mock_proxy.assert_called_once()
+            self.assertTrue(mock_get_fsid.called)
+
+    def test_uncloneable_bad_format(self):
+        with mock.patch.object(self.driver, '_get_fsid') as mock_get_fsid:
+            mock_get_fsid.return_value = 'abc'
+            location = 'rbd://abc/pool/image/snap'
+            formats = ['qcow2', 'vmdk', 'vdi']
+            for f in formats:
+                self.assertFalse(
+                    self.driver.is_cloneable(location, {'disk_format': f}))
+            self.assertTrue(mock_get_fsid.called)
+
+    def test_get_mon_addrs(self):
+        with mock.patch.object(utils, 'execute') as mock_execute:
+            mock_execute.return_value = (CEPH_MON_DUMP, '')
+            hosts = ['::1', '::1', '::1', '127.0.0.1', 'example.com']
+            ports = ['6789', '6790', '6791', '6792', '6791']
+            self.assertEqual((hosts, ports), self.driver.get_mon_addrs())
+
+    @mock.patch.object(rbd_utils, 'RADOSClient')
+    def test_clone(self, mock_client):
+        src_pool = u'images'
+        src_image = u'image-name'
+        src_snap = u'snapshot-name'
+
+        client_stack = []
+
+        def mock__enter__(inst):
+            def _inner():
+                client_stack.append(inst)
+                return inst
+            return _inner
+
+        client = mock_client.return_value
+        # capture both rados client used to perform the clone
+        client.__enter__.side_effect = mock__enter__(client)
+
+        self.mock_rbd.RBD.clone = mock.Mock()
+
+        self.driver.clone(self.rbd_pool, self.volume_name,
+                          src_pool, src_image, src_snap)
+
+        args = [client_stack[0].ioctx, str(src_image), str(src_snap),
+                client_stack[1].ioctx, str(self.volume_name)]
+        kwargs = {'features': self.mock_rbd.RBD_FEATURE_LAYERING}
+        self.mock_rbd.RBD.clone.assert_called_once_with(*args, **kwargs)
+        self.assertEqual(client.__enter__.call_count, 2)
+
+    def test_resize(self):
+        size = 1024
+
+        with mock.patch.object(rbd_utils, 'RBDVolumeProxy') as proxy_init:
+            proxy = proxy_init.return_value
+            proxy.__enter__.return_value = proxy
+            self.driver.resize(self.volume_name, size)
+            proxy.resize.assert_called_once_with(size)
+
+    def test_rbd_volume_proxy_init(self):
+        with mock.patch.object(self.driver, '_connect_to_rados') as \
+                mock_connect_from_rados:
+            with mock.patch.object(self.driver, '_disconnect_from_rados') as \
+                    mock_disconnect_from_rados:
+                mock_connect_from_rados.return_value = (None, None)
+                mock_disconnect_from_rados.return_value = (None, None)
+
+                with rbd_utils.RBDVolumeProxy(self.driver, self.volume_name):
+                    mock_connect_from_rados.assert_called_once()
+                    self.assertFalse(mock_disconnect_from_rados.called)
+
+                mock_disconnect_from_rados.assert_called_once()
+
+    def test_connect_to_rados(self):
+        self.mock_rados.Rados.connect = mock.Mock()
+        self.mock_rados.Rados.shutdown = mock.Mock()
+        self.mock_rados.Rados.open_ioctx = mock.Mock()
+        self.mock_rados.Rados.open_ioctx.return_value = \
+            self.mock_rados.Rados.ioctx
+
+        # default configured pool
+        ret = self.driver._connect_to_rados()
+        self.assertTrue(self.mock_rados.Rados.connect.called)
+        self.assertTrue(self.mock_rados.Rados.open_ioctx.called)
+        self.assertIsInstance(ret[0], self.mock_rados.Rados)
+        self.assertEqual(ret[1], self.mock_rados.Rados.ioctx)
+        self.mock_rados.Rados.open_ioctx.assert_called_with(self.rbd_pool)
+
+        # different pool
+        ret = self.driver._connect_to_rados('alt_pool')
+        self.assertTrue(self.mock_rados.Rados.connect.called)
+        self.assertTrue(self.mock_rados.Rados.open_ioctx.called)
+        self.assertIsInstance(ret[0], self.mock_rados.Rados)
+        self.assertEqual(ret[1], self.mock_rados.Rados.ioctx)
+        self.mock_rados.Rados.open_ioctx.assert_called_with('alt_pool')
+
+        # error
+        self.mock_rados.Rados.open_ioctx.reset_mock()
+        self.mock_rados.Rados.shutdown.reset_mock()
+        self.mock_rados.Rados.open_ioctx.side_effect = self.mock_rados.Error
+        self.assertRaises(self.mock_rados.Error, self.driver._connect_to_rados)
+        self.mock_rados.Rados.open_ioctx.assert_called_once()
+        self.mock_rados.Rados.shutdown.assert_called_once()
+
+    def test_ceph_args(self):
+        self.driver.rbd_user = None
+        self.driver.ceph_conf = None
+        self.assertEqual([], self.driver.ceph_args())
+
+        self.driver.rbd_user = 'foo'
+        self.driver.ceph_conf = None
+        self.assertEqual(['--id', 'foo'], self.driver.ceph_args())
+
+        self.driver.rbd_user = None
+        self.driver.ceph_conf = '/path/bar.conf'
+        self.assertEqual(['--conf', '/path/bar.conf'],
+                         self.driver.ceph_args())
+
+        self.driver.rbd_user = 'foo'
+        self.driver.ceph_conf = '/path/bar.conf'
+        self.assertEqual(['--id', 'foo', '--conf', '/path/bar.conf'],
+                         self.driver.ceph_args())
+
+    def test_exists(self):
+        snapshot = 'snap'
+
+        with mock.patch.object(rbd_utils, 'RBDVolumeProxy') as proxy_init:
+            proxy = proxy_init.return_value
+            self.assertTrue(self.driver.exists(self.volume_name,
+                                               self.rbd_pool,
+                                               snapshot))
+            proxy.__enter__.assert_called_once()
+            proxy.__exit__.assert_called_once()
+
+    def test_rename(self):
+        new_name = 'bar'
+
+        with mock.patch.object(rbd_utils, 'RADOSClient') as client_init:
+            client = client_init.return_value
+            client.__enter__.return_value = client
+            self.mock_rbd.RBD = mock.Mock(return_value=mock.Mock())
+            self.driver.rename(self.volume_name, new_name)
+            mock_rename = self.mock_rbd.RBD.return_value
+            mock_rename.rename.assert_called_once_with(client.ioctx,
+                                                       self.volume_name,
+                                                       new_name)

--- a/nova/virt/libvirt/imagehandler.py
+++ b/nova/virt/libvirt/imagehandler.py
@@ -1,0 +1,107 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""
+RBD clone image handler for libvirt hypervisors.
+"""
+
+from oslo.config import cfg
+
+from nova.openstack.common.gettextutils import _
+from nova.openstack.common import log as logging
+from nova.virt.imagehandler import base
+from nova.virt.libvirt import rbd_utils
+
+CONF = cfg.CONF
+CONF.import_opt('images_rbd_pool', 'nova.virt.libvirt.imagebackend',
+                group='libvirt')
+CONF.import_opt('images_rbd_ceph_conf', 'nova.virt.libvirt.imagebackend',
+                group='libvirt')
+CONF.import_opt('rbd_user', 'nova.virt.libvirt.volume', group='libvirt')
+
+LOG = logging.getLogger(__name__)
+
+
+class RBDCloneImageHandler(base.ImageHandler):
+    """Handler for rbd-backed images.
+
+    If libvirt is using rbd for ephemeral/root disks, this handler
+    will clone images already stored in rbd instead of downloading
+    them locally and importing them into rbd.
+
+    If rbd is not the image backend type, this handler does nothing.
+    """
+    def __init__(self, driver=None, *args, **kwargs):
+        super(RBDCloneImageHandler, self).__init__(driver, *args, **kwargs)
+        if not CONF.libvirt.images_rbd_pool:
+            raise RuntimeError(_('You should specify images_rbd_pool flag in '
+                                 'the libvirt section to use rbd images.'))
+        self.driver = rbd_utils.RBDDriver(
+            pool=CONF.libvirt.images_rbd_pool,
+            ceph_conf=CONF.libvirt.images_rbd_ceph_conf,
+            rbd_user=CONF.libvirt.rbd_user,
+            rbd_lib=kwargs.get('rbd'),
+            rados_lib=kwargs.get('rados'))
+
+    def get_schemes(self):
+        return ('rbd')
+
+    def is_local(self):
+        return False
+
+    def _can_handle_image(self, context, image_meta, location, **kwargs):
+        """Returns whether it makes sense to clone the image.
+
+        - The glance image and libvirt image backend must be rbd.
+        - The image must be readable by the rados user available to nova.
+        - The image must be in raw format.
+        """
+        backend_type = kwargs.get('backend_type')
+        backend_location = kwargs.get('backend_location')
+        if backend_type != 'rbd' or not backend_location:
+            LOG.debug('backend type is not rbd or backend_location is not set')
+            return False
+
+        return self.driver.is_cloneable(location['url'], image_meta)
+
+    def _fetch_image(self, context, image_id, image_meta, path,
+                     user_id=None, project_id=None, location=None,
+                     **kwargs):
+        if not self._can_handle_image(context, image_meta, location, **kwargs):
+            return False
+
+        dest_pool, dest_image = kwargs['backend_location']
+        url = location['url']
+        _fsid, pool, image, snapshot = self.driver.parse_location(url)
+        self.driver.clone(dest_pool, dest_image, pool, image, snapshot)
+        return True
+
+    def _remove_image(self, context, image_id, image_meta, path,
+                      user_id=None, project_id=None, location=None,
+                      **kwargs):
+        if not self._can_handle_image(context, image_meta, location, **kwargs):
+            return False
+
+        pool, image = kwargs['backend_location']
+        self.driver.remove(image)
+        return True
+
+    def _move_image(self, context, image_id, image_meta, src_path, dst_path,
+                    user_id=None, project_id=None, location=None,
+                    **kwargs):
+        if not self._can_handle_image(context, image_meta, location, **kwargs):
+            return False
+
+        src_pool, src_image = kwargs['backend_location']
+        dest_image = kwargs.get('backend_dest')
+        self.driver.rename(src_image, dest_image)
+        return True

--- a/nova/virt/libvirt/rbd_utils.py
+++ b/nova/virt/libvirt/rbd_utils.py
@@ -1,0 +1,234 @@
+# Copyright 2012 Grid Dynamics
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import urllib
+
+try:
+    import rados
+    import rbd
+except ImportError:
+    rados = None
+    rbd = None
+
+from nova import exception
+from nova.openstack.common import excutils
+from nova.openstack.common.gettextutils import _
+from nova.openstack.common import jsonutils
+from nova.openstack.common import log as logging
+from nova import utils
+
+LOG = logging.getLogger(__name__)
+
+
+class RBDVolumeProxy(object):
+    """Context manager for dealing with an existing rbd volume.
+
+    This handles connecting to rados and opening an ioctx automatically, and
+    otherwise acts like a librbd Image object.
+
+    The underlying librados client and ioctx can be accessed as the attributes
+    'client' and 'ioctx'.
+    """
+    def __init__(self, driver, name, pool=None, snapshot=None,
+                 read_only=False):
+        client, ioctx = driver._connect_to_rados(pool)
+        try:
+            snap_name = snapshot.encode('utf8') if snapshot else None
+            self.volume = driver.rbd.Image(ioctx, name.encode('utf8'),
+                                           snapshot=snap_name,
+                                           read_only=read_only)
+        except driver.rbd.ImageNotFound:
+            with excutils.save_and_reraise_exception():
+                LOG.debug("rbd image %s does not exist", name)
+                driver._disconnect_from_rados(client, ioctx)
+        except driver.rbd.Error:
+            with excutils.save_and_reraise_exception():
+                LOG.exception(_("error opening rbd image %s"), name)
+                driver._disconnect_from_rados(client, ioctx)
+
+        self.driver = driver
+        self.client = client
+        self.ioctx = ioctx
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type_, value, traceback):
+        try:
+            self.volume.close()
+        finally:
+            self.driver._disconnect_from_rados(self.client, self.ioctx)
+
+    def __getattr__(self, attrib):
+        return getattr(self.volume, attrib)
+
+
+class RADOSClient(object):
+    """Context manager to simplify error handling for connecting to ceph."""
+    def __init__(self, driver, pool=None):
+        self.driver = driver
+        self.cluster, self.ioctx = driver._connect_to_rados(pool)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type_, value, traceback):
+        self.driver._disconnect_from_rados(self.cluster, self.ioctx)
+
+
+class RBDDriver(object):
+
+    def __init__(self, pool, ceph_conf, rbd_user,
+                 rbd_lib=None, rados_lib=None):
+        self.pool = pool.encode('utf8')
+        self.ceph_conf = ceph_conf.encode('utf8') if ceph_conf else None
+        self.rbd_user = rbd_user.encode('utf8') if rbd_user else None
+        self.rbd = rbd_lib or rbd
+        self.rados = rados_lib or rados
+        if self.rbd is None:
+            raise RuntimeError(_('rbd python libraries not found'))
+
+    def _connect_to_rados(self, pool=None):
+        client = self.rados.Rados(rados_id=self.rbd_user,
+                                  conffile=self.ceph_conf)
+        try:
+            client.connect()
+            pool_to_open = pool or self.pool
+            ioctx = client.open_ioctx(pool_to_open.encode('utf-8'))
+            return client, ioctx
+        except self.rados.Error:
+            # shutdown cannot raise an exception
+            client.shutdown()
+            raise
+
+    def _disconnect_from_rados(self, client, ioctx):
+        # closing an ioctx cannot raise an exception
+        ioctx.close()
+        client.shutdown()
+
+    def supports_layering(self):
+        return hasattr(self.rbd, 'RBD_FEATURE_LAYERING')
+
+    def ceph_args(self):
+        args = []
+        if self.rbd_user:
+            args.extend(['--id', self.rbd_user])
+        if self.ceph_conf:
+            args.extend(['--conf', self.ceph_conf])
+        return args
+
+    def get_mon_addrs(self):
+        args = ['ceph', 'mon', 'dump', '--format=json'] + self.ceph_args()
+        out, _ = utils.execute(*args)
+        lines = out.split('\n')
+        if lines[0].startswith('dumped monmap epoch'):
+            lines = lines[1:]
+        monmap = jsonutils.loads('\n'.join(lines))
+        addrs = [mon['addr'] for mon in monmap['mons']]
+        hosts = []
+        ports = []
+        for addr in addrs:
+            host_port = addr[:addr.rindex('/')]
+            host, port = host_port.rsplit(':', 1)
+            hosts.append(host.strip('[]'))
+            ports.append(port)
+        return hosts, ports
+
+    def parse_location(self, location):
+        prefix = 'rbd://'
+        if not location.startswith(prefix):
+            reason = _('Not stored in rbd')
+            raise exception.ImageUnacceptable(image_id=location, reason=reason)
+        pieces = map(urllib.unquote, location[len(prefix):].split('/'))
+        if '' in pieces:
+            reason = _('Blank components')
+            raise exception.ImageUnacceptable(image_id=location, reason=reason)
+        if len(pieces) != 4:
+            reason = _('Not an rbd snapshot')
+            raise exception.ImageUnacceptable(image_id=location, reason=reason)
+        return pieces
+
+    def _get_fsid(self):
+        with RADOSClient(self) as client:
+            return client.cluster.get_fsid()
+
+    def is_cloneable(self, image_location, image_meta):
+        try:
+            fsid, pool, image, snapshot = self.parse_location(image_location)
+        except exception.ImageUnacceptable as e:
+            LOG.debug(_('not cloneable: %s'), e)
+            return False
+
+        if self._get_fsid() != fsid:
+            reason = _('%s is in a different ceph cluster') % image_location
+            LOG.debug(reason)
+            return False
+
+        if image_meta['disk_format'] != 'raw':
+            reason = _("rbd image clone requires image format to be "
+                       "'raw' but image {0} is '{1}'").format(
+                           image_location, image_meta['disk_format'])
+            LOG.debug(reason)
+            return False
+
+        # check that we can read the image
+        try:
+            return self.exists(image, pool=pool, snapshot=snapshot)
+        except self.rbd.Error as e:
+            LOG.debug(_('Unable to open image %(loc)s: %(err)s') %
+                      dict(loc=image_location, err=e))
+            return False
+
+    def clone(self, dest_pool, dest_image, src_pool, src_image, src_snap):
+        LOG.debug(_('cloning %(pool)s/%(img)s@%(snap)s to %(dstpl)s/%(dst)s') %
+                  dict(pool=src_pool, img=src_image, snap=src_snap,
+                       dst=dest_image, dstpl=dest_pool))
+        with RADOSClient(self, src_pool) as src_client:
+            with RADOSClient(self, dest_pool) as dest_client:
+                self.rbd.RBD().clone(src_client.ioctx,
+                                     src_image.encode('utf-8'),
+                                     src_snap.encode('utf-8'),
+                                     dest_client.ioctx,
+                                     dest_image.encode('utf-8'),
+                                     features=self.rbd.RBD_FEATURE_LAYERING)
+
+    def size(self, name):
+        with RBDVolumeProxy(self, name) as vol:
+            return vol.size()
+
+    def resize(self, name, size_bytes):
+        LOG.debug('resizing rbd image %s to %d', name, size_bytes)
+        with RBDVolumeProxy(self, name) as vol:
+            vol.resize(size_bytes)
+
+    def exists(self, name, pool=None, snapshot=None):
+        try:
+            with RBDVolumeProxy(self, name,
+                                pool=pool,
+                                snapshot=snapshot,
+                                read_only=True):
+                return True
+        except self.rbd.ImageNotFound:
+            return False
+
+    def remove(self, name):
+        LOG.debug('removing rbd image %s', name)
+        with RBDVolumeProxy(self, name) as vol:
+            vol.remove()
+
+    def rename(self, name, new_name):
+        LOG.debug('renaming rbd image %s to %s', name, new_name)
+        with RADOSClient(self) as client:
+            self.rbd.RBD().rename(client.ioctx,
+                                  name.encode('utf-8'),
+                                  new_name.encode('utf-8'))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = nova
-version = 2013.2.3
+version = 2014.1
 summary = Cloud computing fabric controller
 description-file =
     README.rst
@@ -29,6 +29,9 @@ packages =
 [entry_points]
 nova.image.download.modules =
     file = nova.image.download.file
+nova.virt.image.handlers =
+    download = nova.virt.imagehandler.download:DownloadImageHandler
+    libvirt_rbd_clone = nova.virt.libvirt.imagehandler:RBDCloneImageHandler
 console_scripts =
     nova-all = nova.cmd.all:main
     nova-api = nova.cmd.api:main
@@ -50,12 +53,13 @@ console_scripts =
     nova-network = nova.cmd.network:main
     nova-novncproxy = nova.cmd.novncproxy:main
     nova-objectstore = nova.cmd.objectstore:main
-    nova-rootwrap = nova.openstack.common.rootwrap.cmd:main
+    nova-rootwrap = oslo.rootwrap.cmd:main
     nova-scheduler = nova.cmd.scheduler:main
     nova-spicehtml5proxy = nova.cmd.spicehtml5proxy:main
     nova-xvpvncproxy = nova.cmd.xvpvncproxy:main
 
 nova.api.v3.extensions =
+    access_ips = nova.api.openstack.compute.plugins.v3.access_ips:AccessIPs
     admin_actions = nova.api.openstack.compute.plugins.v3.admin_actions:AdminActions
     admin_password = nova.api.openstack.compute.plugins.v3.admin_password:AdminPassword
     agents = nova.api.openstack.compute.plugins.v3.agents:Agents
@@ -66,11 +70,11 @@ nova.api.v3.extensions =
     cells = nova.api.openstack.compute.plugins.v3.cells:Cells
     certificates = nova.api.openstack.compute.plugins.v3.certificates:Certificates
     config_drive = nova.api.openstack.compute.plugins.v3.config_drive:ConfigDrive
+    console_auth_tokens = nova.api.openstack.compute.plugins.v3.console_auth_tokens:ConsoleAuthTokens
     console_output = nova.api.openstack.compute.plugins.v3.console_output:ConsoleOutput
     consoles = nova.api.openstack.compute.plugins.v3.consoles:Consoles
-    coverage = nova.api.openstack.compute.plugins.v3.coverage:Coverage
+    create_backup = nova.api.openstack.compute.plugins.v3.create_backup:CreateBackup
     deferred_delete = nova.api.openstack.compute.plugins.v3.deferred_delete:DeferredDelete
-    disk_config = nova.api.openstack.compute.plugins.v3.disk_config:DiskConfig
     evacuate = nova.api.openstack.compute.plugins.v3.evacuate:Evacuate
     extended_availability_zone = nova.api.openstack.compute.plugins.v3.extended_availability_zone:ExtendedAvailabilityZone
     extended_server_attributes = nova.api.openstack.compute.plugins.v3.extended_server_attributes:ExtendedServerAttributes
@@ -87,13 +91,14 @@ nova.api.v3.extensions =
     hypervisors = nova.api.openstack.compute.plugins.v3.hypervisors:Hypervisors
     instance_actions = nova.api.openstack.compute.plugins.v3.instance_actions:InstanceActions
     ips = nova.api.openstack.compute.plugins.v3.ips:IPs
-    instance_usage_audit_log = nova.api.openstack.compute.plugins.v3.instance_usage_audit_log:InstanceUsageAuditLog
     keypairs = nova.api.openstack.compute.plugins.v3.keypairs:Keypairs
-    limits = nova.api.openstack.compute.plugins.v3.limits:Limits
+    lock_server = nova.api.openstack.compute.plugins.v3.lock_server:LockServer
+    migrate_server = nova.api.openstack.compute.plugins.v3.migrate_server:MigrateServer
     migrations = nova.api.openstack.compute.plugins.v3.migrations:Migrations
     multinic = nova.api.openstack.compute.plugins.v3.multinic:Multinic
     multiple_create = nova.api.openstack.compute.plugins.v3.multiple_create:MultipleCreate
-    quota_classes = nova.api.openstack.compute.plugins.v3.quota_classes:QuotaClasses
+    pause_server = nova.api.openstack.compute.plugins.v3.pause_server:PauseServer
+    pci = nova.api.openstack.compute.plugins.v3.pci:Pci
     quota_sets = nova.api.openstack.compute.plugins.v3.quota_sets:QuotaSets
     remote_consoles = nova.api.openstack.compute.plugins.v3.remote_consoles:RemoteConsoles
     rescue = nova.api.openstack.compute.plugins.v3.rescue:Rescue
@@ -106,49 +111,33 @@ nova.api.v3.extensions =
     servers = nova.api.openstack.compute.plugins.v3.servers:Servers
     services = nova.api.openstack.compute.plugins.v3.services:Services
     shelve = nova.api.openstack.compute.plugins.v3.shelve:Shelve
-    simple_tenant_usage = nova.api.openstack.compute.plugins.v3.simple_tenant_usage:SimpleTenantUsage
-    used_limits = nova.api.openstack.compute.plugins.v3.used_limits:UsedLimits
+    suspend_server = nova.api.openstack.compute.plugins.v3.suspend_server:SuspendServer
     versions = nova.api.openstack.compute.plugins.v3.versions:Versions
 
 nova.api.v3.extensions.server.create =
+    access_ips = nova.api.openstack.compute.plugins.v3.access_ips:AccessIPs
     availability_zone = nova.api.openstack.compute.plugins.v3.availability_zone:AvailabilityZone
     block_device_mapping = nova.api.openstack.compute.plugins.v3.block_device_mapping:BlockDeviceMapping
     config_drive = nova.api.openstack.compute.plugins.v3.config_drive:ConfigDrive
-    disk_config = nova.api.openstack.compute.plugins.v3.disk_config:DiskConfig
     keypairs_create = nova.api.openstack.compute.plugins.v3.keypairs:Keypairs
     multiple_create = nova.api.openstack.compute.plugins.v3.multiple_create:MultipleCreate
-    personalities = nova.api.openstack.compute.plugins.v3.personalities:Personalities
-    scheduler_hints = nova.api.openstack.compute.plugins.v3.scheduler_hints:SchedulerHints
-    security_groups = nova.api.openstack.compute.plugins.v3.security_groups:SecurityGroups
-    user_data = nova.api.openstack.compute.plugins.v3.user_data:UserData
-
-nova.api.v3.extensions.server.create.deserialize =
-    availability_zone = nova.api.openstack.compute.plugins.v3.availability_zone:AvailabilityZone
-    block_device_mapping = nova.api.openstack.compute.plugins.v3.block_device_mapping:BlockDeviceMapping
-    config_drive = nova.api.openstack.compute.plugins.v3.config_drive:ConfigDrive
-    disk_config = nova.api.openstack.compute.plugins.v3.disk_config:DiskConfig
-    multiple_create = nova.api.openstack.compute.plugins.v3.multiple_create:MultipleCreate
-    personalities = nova.api.openstack.compute.plugins.v3.personalities:Personalities
     scheduler_hints = nova.api.openstack.compute.plugins.v3.scheduler_hints:SchedulerHints
     security_groups = nova.api.openstack.compute.plugins.v3.security_groups:SecurityGroups
     user_data = nova.api.openstack.compute.plugins.v3.user_data:UserData
 
 nova.api.v3.extensions.server.rebuild =
-    disk_config = nova.api.openstack.compute.plugins.v3.disk_config:DiskConfig
-    personalities = nova.api.openstack.compute.plugins.v3.personalities:Personalities
-
-nova.api.v3.extensions.server.rebuild.deserialize =
-    disk_config = nova.api.openstack.compute.plugins.v3.disk_config:DiskConfig
-    personalities = nova.api.openstack.compute.plugins.v3.personalities:Personalities
-
-nova.api.v3.extensions.server.resize =
-    disk_config = nova.api.openstack.compute.plugins.v3.disk_config:DiskConfig
-
-nova.api.v3.extensions.server.resize.deserialize =
-    disk_config = nova.api.openstack.compute.plugins.v3.disk_config:DiskConfig
+    access_ips = nova.api.openstack.compute.plugins.v3.access_ips:AccessIPs
 
 nova.api.v3.extensions.server.update =
-    disk_config = nova.api.openstack.compute.plugins.v3.disk_config:DiskConfig
+    access_ips = nova.api.openstack.compute.plugins.v3.access_ips:AccessIPs
+
+# These are for backwards compat with Havana notification_driver configuration values
+oslo.messaging.notify.drivers =
+    nova.openstack.common.notifier.log_notifier = oslo.messaging.notify._impl_log:LogDriver
+    nova.openstack.common.notifier.no_op_notifier = oslo.messaging.notify._impl_noop:NoOpDriver
+    nova.openstack.common.notifier.rpc_notifier2 = oslo.messaging.notify._impl_messaging:MessagingV2Driver
+    nova.openstack.common.notifier.rpc_notifier = oslo.messaging.notify._impl_messaging:MessagingDriver
+    nova.openstack.common.notifier.test_notifier = oslo.messaging.notify._impl_test:TestDriver
 
 [build_sphinx]
 all_files = 1


### PR DESCRIPTION
Currently when using rbd as an image backend, nova downloads the
glance image to local disk and then copies it again into rbd. This
can be very slow for large images, and wastes bandwidth as well as
disk space.

When the glance image is stored in the same ceph cluster, the data is
being pulled out and pushed back in unnecessarily. Instead, create a
copy-on-write clone of the image. This is fast, and does not depend
on the size of the image. Instead of taking minutes, booting takes
seconds, and is not limited by the disk copy.

Add some rbd utility functions from cinder to support cloning and
let the rbd imagebackend rely on librbd instead of the rbd
command line tool for checking image existence.

Add an ImageHandler for rbd that does the cloning if an applicable
image location is available. If no such location is available, or rbd
is not configured for ephemeral disks, this handler does nothing, so
enable it by default.

blueprint rbd-clone-image-handler
Closes-bug: 1226351
Change-Id: I9b77a50206d0eda709df8356faaeeba35d232f22
Signed-off-by: Josh Durgin josh.durgin@inktank.com
Signed-off-by: Zhi Yan Liu zhiyanl@cn.ibm.com

Conflicts:
    nova/tests/virt/libvirt/test_imagebackend.py
    nova/tests/virt/libvirt/test_rbd_utils.py
    nova/virt/libvirt/imagebackend.py
    nova/virt/libvirt/rbd_utils.py
    setup.cfg
