### PR TITLE
Per aggregate filters from community

### DIFF
--- a/doc/source/devref/filter_scheduler.rst
+++ b/doc/source/devref/filter_scheduler.rst
@@ -89,6 +89,28 @@ There are some standard filter classes to use (:mod:`nova.scheduler.filters`):
   fall back to the global default ``ram_allocation_ratio``. If more than one value
   is found for a host (meaning the host is in two differenet aggregate with
   different ratio settings), the minimum value will be used.
+* |DiskFilter| - filters hosts by their disk allocation. Only hosts with sufficient
+  disk space to host the instance are passed.
+  ``disk_allocation_ration`` setting. It's virtual disk to physical disk
+  allocation ratio and it's 1.0 by default. The total allow allocated disk size will
+  be physical disk multiplied this ratio.
+* |AggregateDiskFilter| - filters hosts by disk allocation with per-aggregate
+  ``disk_allocation_ratio`` setting. If no per-aggregate value is found, it will
+  fall back to the global default ``disk_allocation_ratio``. If more than one value
+  is found for a host (meaning the host is in two or more different aggregates with
+  different ratio settings), the minimum value will be used.
+* |NumInstancesFilter| - filters hosts by number of running instances on it.
+  hosts with too many instances will be filtered.
+  ``max_instances_per_host`` setting. Maximum number of instances allowed to run on
+  this host, the host will be ignored by scheduler if more than ``max_instances_per_host``
+  are already existing on the host.
+* |IoOpsFilter| - filters hosts by concurrent I/O operations on it.
+  hosts with too many concurrent I/O operations will be filtered.
+  ``max_io_ops_per_host`` setting. Maximum number of I/O intensive instances allowed to
+  run on this host, the host will be ignored by scheduler if more than ``max_io_ops_per_host``
+  instances such as build/resize/snapshot etc are running on it.
+* |PciPassthroughFilter| - Filter that schedules instances on a host if the host
+  has devices to meet the device requests in the 'extra_specs' for the flavor.
 * |SimpleCIDRAffinityFilter| - allows to put a new instance on a host within
   the same IP block.
 * |DifferentHostFilter| - allows to put the instance on a different host from a
@@ -296,6 +318,11 @@ in :mod:``nova.tests.scheduler``.
 .. |JsonFilter| replace:: :class:`JsonFilter <nova.scheduler.filters.json_filter.JsonFilter>`
 .. |RamFilter| replace:: :class:`RamFilter <nova.scheduler.filters.ram_filter.RamFilter>`
 .. |AggregateRamFilter| replace:: :class:`AggregateRamFilter <nova.scheduler.filters.ram_filter.AggregateRamFilter>`
+.. |DiskFilter| replace:: :class:`DiskFilter <nova.scheduler.filters.disk_filter.DiskFilter>`
+.. |AggregateDiskFilter| replace:: :class:`AggregateDiskFilter <nova.scheduler.filters.disk_filter.AggregateDiskFilter>`
+.. |NumInstancesFilter| replace:: :class:`NumInstancesFilter <nova.scheduler.filters.num_instances_filter.NumInstancesFilter>`
+.. |IoOpsFilter| replace:: :class:`IoOpsFilter <nova.scheduler.filters.io_ops_filter.IoOpsFilter>`
+.. |PciPassthroughFilter| replace:: :class:`PciPassthroughFilter <nova.scheduler.filters.pci_passthrough_filter.PciPassthroughFilter>`
 .. |SimpleCIDRAffinityFilter| replace:: :class:`SimpleCIDRAffinityFilter <nova.scheduler.filters.affinity_filter.SimpleCIDRAffinityFilter>`
 .. |GroupAntiAffinityFilter| replace:: :class:`GroupAntiAffinityFilter <nova.scheduler.filters.affinity_filter.GroupAntiAffinityFilter>`
 .. |GroupAffinityFilter| replace:: :class:`GroupAffinityFilter <nova.scheduler.filters.affinity_filter.GroupAffinityFilter>`

--- a/nova/objects/aggregate.py
+++ b/nova/objects/aggregate.py
@@ -152,7 +152,7 @@ class AggregateList(base.ObjectListBase, base.NovaObject):
                                   db_aggregates)
 
     @base.remotable_classmethod
-    def get_by_host(cls, context, host):
-        db_aggregates = db.aggregate_get_by_host(context, host)
+    def get_by_host(cls, context, host, key=None):
+        db_aggregates = db.aggregate_get_by_host(context, host, key=key)
         return base.obj_make_list(context, AggregateList(), Aggregate,
                                   db_aggregates)

--- a/nova/scheduler/filters/disk_filter.py
+++ b/nova/scheduler/filters/disk_filter.py
@@ -18,6 +18,7 @@ from oslo.config import cfg
 from nova.openstack.common.gettextutils import _
 from nova.openstack.common import log as logging
 from nova.scheduler import filters
+from nova.scheduler.filters import utils
 
 LOG = logging.getLogger(__name__)
 
@@ -31,16 +32,23 @@ CONF.register_opt(disk_allocation_ratio_opt)
 class DiskFilter(filters.BaseHostFilter):
     """Disk Filter with over subscription flag."""
 
+    def _get_disk_allocation_ratio(self, host_state, filter_properties):
+        return CONF.disk_allocation_ratio
+
     def host_passes(self, host_state, filter_properties):
         """Filter based on disk usage."""
         instance_type = filter_properties.get('instance_type')
-        requested_disk = 1024 * (instance_type['root_gb'] +
-                                 instance_type['ephemeral_gb'])
+        requested_disk = (1024 * (instance_type['root_gb'] +
+                                 instance_type['ephemeral_gb']) +
+                         instance_type['swap'])
 
         free_disk_mb = host_state.free_disk_mb
         total_usable_disk_mb = host_state.total_usable_disk_gb * 1024
 
-        disk_mb_limit = total_usable_disk_mb * CONF.disk_allocation_ratio
+        disk_allocation_ratio = self._get_disk_allocation_ratio(
+            host_state, filter_properties)
+
+        disk_mb_limit = total_usable_disk_mb * disk_allocation_ratio
         used_disk_mb = total_usable_disk_mb - free_disk_mb
         usable_disk_mb = disk_mb_limit - used_disk_mb
 
@@ -55,3 +63,28 @@ class DiskFilter(filters.BaseHostFilter):
         disk_gb_limit = disk_mb_limit / 1024
         host_state.limits['disk_gb'] = disk_gb_limit
         return True
+
+
+class AggregateDiskFilter(DiskFilter):
+    """AggregateDiskFilter with per-aggregate disk allocation ratio flag.
+
+    Fall back to global disk_allocation_ratio if no per-aggregate setting
+    found.
+    """
+
+    def _get_disk_allocation_ratio(self, host_state, filter_properties):
+        # TODO(uni): DB query in filter is a performance hit, especially for
+        # system with lots of hosts. Will need a general solution here to fix
+        # all filters with aggregate DB call things.
+        aggregate_vals = utils.aggregate_values_from_db(
+            filter_properties['context'],
+            host_state.host,
+            'disk_allocation_ratio')
+        try:
+            ratio = utils.validate_num_values(
+                aggregate_vals, CONF.disk_allocation_ratio, cast_to=float)
+        except ValueError as e:
+            LOG.warn(_("Could not decode disk_allocation_ratio: '%s'"), e)
+            ratio = CONF.disk_allocation_ratio
+
+        return ratio

--- a/nova/scheduler/filters/ram_filter.py
+++ b/nova/scheduler/filters/ram_filter.py
@@ -16,10 +16,10 @@
 
 from oslo.config import cfg
 
-from nova import db
 from nova.openstack.common.gettextutils import _
 from nova.openstack.common import log as logging
 from nova.scheduler import filters
+from nova.scheduler.filters import utils
 
 LOG = logging.getLogger(__name__)
 
@@ -79,25 +79,17 @@ class AggregateRamFilter(BaseRamFilter):
     """
 
     def _get_ram_allocation_ratio(self, host_state, filter_properties):
-        context = filter_properties['context'].elevated()
         # TODO(uni): DB query in filter is a performance hit, especially for
         # system with lots of hosts. Will need a general solution here to fix
         # all filters with aggregate DB call things.
-        metadata = db.aggregate_metadata_get_by_host(
-                     context, host_state.host, key='ram_allocation_ratio')
-        aggregate_vals = metadata.get('ram_allocation_ratio', set())
-        num_values = len(aggregate_vals)
-
-        if num_values == 0:
-            return CONF.ram_allocation_ratio
-
-        if num_values > 1:
-            LOG.warning(_("%(num_values)d ratio values found, "
-                          "of which the minimum value will be used."),
-                         {'num_values': num_values})
+        aggregate_vals = utils.aggregate_values_from_db(
+            filter_properties['context'],
+            host_state.host,
+            'ram_allocation_ratio')
 
         try:
-            ratio = float(min(aggregate_vals))
+            ratio = utils.validate_num_values(
+                aggregate_vals, CONF.ram_allocation_ratio, cast_to=float)
         except ValueError as e:
             LOG.warning(_("Could not decode ram_allocation_ratio: '%s'"), e)
             ratio = CONF.ram_allocation_ratio

--- a/nova/scheduler/filters/utils.py
+++ b/nova/scheduler/filters/utils.py
@@ -1,0 +1,54 @@
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Bench of utility methods used by filters."""
+
+
+from nova.objects import aggregate
+from nova.openstack.common.gettextutils import _
+from nova.openstack.common import log as logging
+
+LOG = logging.getLogger(__name__)
+
+
+def aggregate_values_from_db(context, host, key_name):
+    """Returns a set of values based on a metadata key for a specific host."""
+    # TODO(sahid): DB query in filter is a performance hit, especially for
+    # system with lots of hosts. Will need a general solution here to fix
+    # all filters with aggregate DB call things.
+    aggrlist = aggregate.AggregateList.get_by_host(
+        context.elevated(), host, key=key_name)
+    aggregate_vals = set(aggr.metadata[key_name] for aggr in aggrlist)
+    return aggregate_vals
+
+
+def validate_num_values(vals, default=None, cast_to=int, based_on=min):
+    """Returns a correctly casted value based on a set of values.
+
+    This method is useful to work with per-aggregate filters, It takes
+    a set of values then return the 'based_on'{min/max} converted to
+    'cast_to' of the set or the default value.
+
+    Note: The cast implies a possible ValueError
+    """
+    num_values = len(vals)
+    if num_values == 0:
+        return default
+
+    if num_values > 1:
+        LOG.info(_("%(num_values)d values found, "
+                     "of which the minimum value will be used."),
+                 {'num_values': num_values})
+
+    return cast_to(based_on(vals))

--- a/nova/tests/objects/test_aggregate.py
+++ b/nova/tests/objects/test_aggregate.py
@@ -133,7 +133,7 @@ class _TestAggregateObject(object):
 
     def test_by_host(self):
         self.mox.StubOutWithMock(db, 'aggregate_get_by_host')
-        db.aggregate_get_by_host(self.context, 'fake-host'
+        db.aggregate_get_by_host(self.context, 'fake-host', key=None
                                  ).AndReturn([fake_aggregate])
         self.mox.ReplayAll()
         aggs = aggregate.AggregateList.get_by_host(self.context, 'fake-host')

--- a/nova/tests/scheduler/test_filters_utils.py
+++ b/nova/tests/scheduler/test_filters_utils.py
@@ -1,0 +1,44 @@
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import mock
+
+from nova.scheduler.filters import utils
+from nova import test
+
+
+class UtilsTestCase(test.NoDBTestCase):
+    def test_validate_num_values(self):
+        f = utils.validate_num_values
+
+        self.assertEqual("x", f(set(), default="x"))
+        self.assertEqual(1, f(set(["1"]), cast_to=int))
+        self.assertEqual(1.0, f(set(["1"]), cast_to=float))
+        self.assertEqual(1, f(set([1, 2]), based_on=min))
+        self.assertEqual(2, f(set([1, 2]), based_on=max))
+
+    @mock.patch("nova.objects.aggregate.AggregateList.get_by_host")
+    def test_aggregate_values_from_db(self, get_by_host):
+        aggrA = mock.MagicMock()
+        aggrB = mock.MagicMock()
+        context = mock.MagicMock()
+
+        get_by_host.return_value = [aggrA, aggrB]
+        aggrA.metadata = {'k1': 1, 'k2': 2}
+        aggrB.metadata = {'k1': 3, 'k2': 4}
+
+        values = utils.aggregate_values_from_db(context, 'h1', key_name='k1')
+
+        self.assertTrue(context.elevated.called)
+        self.assertEqual(set([1, 3]), values)

--- a/nova/tests/virt/libvirt/fakelibvirt.py
+++ b/nova/tests/virt/libvirt/fakelibvirt.py
@@ -512,7 +512,7 @@ class DomainSnapshot(object):
 
 
 class Connection(object):
-    def __init__(self, uri, readonly, version=9007):
+    def __init__(self, uri=None, readonly=False, version=9007):
         if not uri or uri == '':
             if allow_default_uri_connection:
                 uri = 'qemu:///session'


### PR DESCRIPTION
1. Fix unit test test_libvirt.test_tpool_execute_calls_libvirt by add default arguments for the fakelibvirt.Connection class. (backported from icehouse )
2. Introduce a new file of utility methods to deal with aggregate metadata.  (backported from juno )
3. Add per-aggregate filter (backported from juno )
