### PR TITLE
Use Ceph cluster stats to report disk info on RBD

### DIFF
--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -3450,6 +3450,9 @@ class LibvirtDriver(driver.ComputeDriver):
         if CONF.libvirt_images_type == 'lvm':
             info = libvirt_utils.get_volume_group_info(
                                  CONF.libvirt_images_volume_group)
+        elif CONF.libvirt_images_type == 'rbd':
+            info = libvirt_utils.get_rbd_pool_info(
+                                 CONF.libvirt_images_rbd_pool)
         else:
             info = libvirt_utils.get_fs_info(CONF.instances_path)
 

--- a/nova/virt/libvirt/utils.py
+++ b/nova/virt/libvirt/utils.py
@@ -319,6 +319,14 @@ def remove_rbd_volumes(pool, *names):
                      {'name': name, 'pool': pool})
 
 
+def get_rbd_pool_info(pool):
+    client, ioctx = _connect_to_rados(pool)
+    stats = client.get_cluster_stats()
+    return {'total': stats['kb'] * 1024,
+            'free': stats['kb_avail'] * 1024,
+            'used': stats['kb_used'] * 1024}
+
+
 def get_volume_group_info(vg):
     """Return free/used/total space info for a volume group in bytes
 


### PR DESCRIPTION
Local disk statistics on compute nodes are irrelevant when ephemeral
disks are stored in RBD. With RBD, local disk space is not consumed when
instances are started on a compute node, yet it is possible for
scheduler to refuse to schedule an instance when combined disk usage of
instances already running on the node exceeds total disk capacity
reported by the hypervisor driver.

Closes-bug: #1332660

Change-Id: If239a1e098c0482d41f51ef51608d59b50f6924a
Upstream-Review: https://review.openstack.org/#/c/102064/
Closes-rally-bug: DE767
Backported-from: juno
