### PR TITLE
Use libvirt filters for network security

### DIFF
--- a/nova/network/neutronv2/api.py
+++ b/nova/network/neutronv2/api.py
@@ -980,6 +980,7 @@ class API(base.Base):
             if port['network_id'] == net['id']:
                 network_name = net['name']
                 tenant_id = net['tenant_id']
+                shared = net['shared']
                 break
         else:
             tenant_id = port['tenant_id']
@@ -1013,6 +1014,7 @@ class API(base.Base):
             tenant_id=tenant_id
             )
         network['subnets'] = subnets
+        network['shared'] = shared
         port_profile = port.get('binding:profile')
         if port_profile:
             physical_network = port_profile.get('physical_network')

--- a/nova/virt/firewall.py
+++ b/nova/virt/firewall.py
@@ -561,3 +561,25 @@ class NoopFirewallDriver(object):
 
     def instance_filter_exists(self, instance, network_info):
         return True
+
+
+class EbtablesFirewallDriver(FirewallDriver):
+    """Firewall driver which just provides basic filtering."""
+    def __init__(self, virtapi, **kwargs):
+        super(EbtablesFirewallDriver, self).__init__(virtapi)
+        self.basically_filtered = False
+
+    def prepare_instance_filter(self, instance, network_info):
+        pass
+
+    def unfilter_instance(self, instance, network_info):
+        pass
+
+    def apply_instance_filter(self, instance, network_info):
+        pass
+
+    def setup_basic_filtering(self, instance, network_info):
+        pass
+
+    def instance_filter_exists(self, instance, network_info):
+        pass


### PR DESCRIPTION
Use libvirt default network filters, no-arp-spoofing, no-ip-spoofing, and no-mac-spoofing.
Use existing nova network filter nova-no-nd-reflection.
These filters add rules to the ebtables, and do not conflict with neutron security groups.

Closes-rally-bug: DE789 DE701 DE714 DE505
Implements: rally-task TA5323
Not-in-upstream: true
