### PR TITLE
Merge rbd cloning edited

### DIFF
--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -4145,8 +4145,8 @@ class ComputeManager(manager.SchedulerDependentManager):
         # No instance booting at source host, but instance dir
         # must be deleted for preparing next block migration
         # must be deleted for preparing next live migration w/o shared storage
-        is_shared_block_storage = False
-        is_shared_instance_path = False
+        is_shared_block_storage = True
+        is_shared_instance_path = True
         if migrate_data:
             is_shared_block_storage = migrate_data.get(
                     'is_shared_block_storage', True)
@@ -4155,7 +4155,8 @@ class ComputeManager(manager.SchedulerDependentManager):
 
         if block_migration or not is_shared_instance_path:
             self.driver.destroy(instance_ref, network_info,
-                    destroy_disks = not is_shared_block_storage)
+                    destroy_disks=not is_shared_block_storage,
+                    migrate_data=migrate_data)
         else:
             # self.driver.destroy() usually performs  vif unplugging
             # but we must do it explicitly here when block_migration
@@ -4285,9 +4286,10 @@ class ComputeManager(manager.SchedulerDependentManager):
                     'is_shared_block_storage', True)
             is_shared_instance_path = migrate_data.get(
                     'is_shared_instance_path', True)
-        if block_migration or (is_shared_block_storage and not is_shared_instance_path):
+        if block_migration or (
+                is_shared_block_storage and not is_shared_instance_path):
             self.compute_rpcapi.rollback_live_migration_at_destination(context,
-                    instance, dest, destroy_disks = not is_shared_block_storage)
+                    instance, dest, destroy_disks=not is_shared_block_storage)
 
         self._notify_about_instance_usage(context, instance,
                                           "live_migration._rollback.end")

--- a/nova/tests/virt/libvirt/test_imagebackend.py
+++ b/nova/tests/virt/libvirt/test_imagebackend.py
@@ -402,14 +402,14 @@ class Qcow2TestCase(_ImageTestCase, test.NoDBTestCase):
     def test_create_image_too_small(self):
         fn = self.prepare_mocks()
         self.mox.StubOutWithMock(os.path, 'exists')
-        self.mox.StubOutWithMock(imagebackend.disk, 'get_disk_size')
+        self.mox.StubOutWithMock(imagebackend.Qcow2, 'get_disk_size')
         if self.OLD_STYLE_INSTANCE_PATH:
             os.path.exists(self.OLD_STYLE_INSTANCE_PATH).AndReturn(False)
         os.path.exists(self.DISK_INFO_PATH).AndReturn(False)
         os.path.exists(self.INSTANCES_PATH).AndReturn(True)
         os.path.exists(self.TEMPLATE_PATH).AndReturn(True)
-        imagebackend.disk.get_disk_size(self.TEMPLATE_PATH
-                                       ).AndReturn(self.SIZE)
+        imagebackend.Qcow2.get_disk_size(self.TEMPLATE_PATH
+                                         ).AndReturn(self.SIZE)
         self.mox.ReplayAll()
 
         image = self.image_class(self.INSTANCE, self.NAME)

--- a/nova/tests/virt/libvirt/test_imagebackend.py
+++ b/nova/tests/virt/libvirt/test_imagebackend.py
@@ -402,14 +402,14 @@ class Qcow2TestCase(_ImageTestCase, test.NoDBTestCase):
     def test_create_image_too_small(self):
         fn = self.prepare_mocks()
         self.mox.StubOutWithMock(os.path, 'exists')
-        self.mox.StubOutWithMock(imagebackend.Qcow2, 'get_disk_size')
+        self.mox.StubOutWithMock(imagebackend.disk, 'get_disk_size')
         if self.OLD_STYLE_INSTANCE_PATH:
             os.path.exists(self.OLD_STYLE_INSTANCE_PATH).AndReturn(False)
         os.path.exists(self.DISK_INFO_PATH).AndReturn(False)
         os.path.exists(self.INSTANCES_PATH).AndReturn(True)
         os.path.exists(self.TEMPLATE_PATH).AndReturn(True)
-        imagebackend.Qcow2.get_disk_size(self.TEMPLATE_PATH
-                                         ).AndReturn(self.SIZE)
+        imagebackend.disk.get_disk_size(self.TEMPLATE_PATH
+                                       ).AndReturn(self.SIZE)
         self.mox.ReplayAll()
 
         image = self.image_class(self.INSTANCE, self.NAME)
@@ -811,27 +811,15 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
 
         self.mox.VerifyAll()
 
-    def test_cache_base_dir_exists(self):
-        self.mox.StubOutWithMock(os.path, 'exists')
-        os.path.exists(self.TEMPLATE_DIR).AndReturn(True)
-        os.path.exists(self.TEMPLATE_PATH).AndReturn(False)
-        fn = self.mox.CreateMockAnything()
-        fn(target=self.TEMPLATE_PATH)
-        self.mox.StubOutWithMock(imagebackend.fileutils, 'ensure_tree')
-        self.mox.ReplayAll()
-
-        image = self.image_class(self.INSTANCE, self.NAME)
-        self.mock_create_image(image)
-        image.cache(fn, self.TEMPLATE)
-
-        self.mox.VerifyAll()
-
     def test_create_image(self):
         fn = self.prepare_mocks()
         fn(max_size=None, rbd=self.rbd, target=self.TEMPLATE_PATH)
 
         self.rbd.RBD_FEATURE_LAYERING = 1
 
+        self.mox.StubOutWithMock(imagebackend.disk, 'get_disk_size')
+        imagebackend.disk.get_disk_size(self.TEMPLATE_PATH
+                                       ).AndReturn(self.SIZE)
         rbd_name = "%s/%s" % (self.INSTANCE['name'], self.NAME)
         cmd = ('--pool', self.POOL, self.TEMPLATE_PATH,
                rbd_name, '--new-format', '--id', self.USER,
@@ -976,21 +964,6 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
         self.mox.ReplayAll()
 
         self.assertFalse(image._is_cloneable(location))
-
-    def test_image_path(self):
-
-        conf = "FakeConf"
-        pool = "FakePool"
-        user = "FakeUser"
-
-        self.flags(libvirt_images_rbd_pool=pool)
-        self.flags(libvirt_images_rbd_ceph_conf=conf)
-        self.flags(rbd_user=user)
-        image = self.image_class(self.INSTANCE, self.NAME)
-        rbd_path = "rbd:%s/%s:id=%s:conf=%s" % (pool, image.rbd_name,
-                                                user, conf)
-
-        self.assertEqual(image.path, rbd_path)
 
 
 class BackendTestCase(test.NoDBTestCase):

--- a/nova/tests/virt/libvirt/test_imagebackend.py
+++ b/nova/tests/virt/libvirt/test_imagebackend.py
@@ -880,27 +880,56 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
 
         self.mox.VerifyAll()
 
-    def test_direct_fetch_fail(self):
+    def test_direct_fetch_fail_no_layering_support(self):
+        self.prepare_mocks()
         image = self.image_class(self.INSTANCE, self.NAME)
-        self.stubs.Set(image, '_is_cloneable', lambda: True)
-        self.assertRaises(exception.ImageUnacceptable,
-                          image.direct_fetch, 'image_id',
-                          {'disk_format': 'raw'},
-                          [{'url': 'rbd://a/b/c/d'}])
-        self.rbd.RBD_FEATURE_LAYERING = 1
-        self.assertRaises(exception.ImageUnacceptable,
-                          image.direct_fetch, 'image_id',
-                          {},
-                          [{'url': 'rbd://a/b/c/d'}])
-        self.assertRaises(exception.ImageUnacceptable,
-                          image.direct_fetch, 'image_id',
-                          {'disk_format': 'raw'},
-                          [])
-        self.stubs.Set(image, '_is_cloneable', lambda: False)
-        self.assertRaises(exception.ImageUnacceptable,
-                          image.direct_fetch, 'image_id',
-                          {'disk_format': 'raw'},
-                          [{'url': 'rbd://a/b/c/d'}])
+        self.stubs.Set(image, '_supports_layering', lambda: False)
+        self.assertRaisesRegexp(
+            exception.ImageUnacceptable,
+            'installed version of librbd does not support cloning',
+            image.direct_fetch,
+            'image_id',
+            {'disk_format': 'raw'},
+            [{'url': 'rbd://a/b/c/d'}]
+        )
+
+    def test_direct_fetch_fail_no_supported_image_format(self):
+        self.prepare_mocks()
+        image = self.image_class(self.INSTANCE, self.NAME)
+        self.assertRaisesRegexp(
+            exception.ImageUnacceptable,
+            'Image is not raw format',
+            image.direct_fetch,
+            'image_id',
+            {},
+            [{'url': 'rbd://a/b/c/d'}]
+        )
+
+    def test_direct_fetch_fail_no_image_locations(self):
+        self.prepare_mocks()
+        image = self.image_class(self.INSTANCE, self.NAME)
+        self.stubs.Set(image, '_is_cloneable', lambda x: True)
+        self.assertRaisesRegexp(
+            exception.ImageUnacceptable,
+            'No image locations are accessible',
+            image.direct_fetch,
+            'image_id',
+            {'disk_format': 'raw'},
+            []
+        )
+
+    def test_direct_fetch_fail_no_cloneable_image(self):
+        self.prepare_mocks()
+        image = self.image_class(self.INSTANCE, self.NAME)
+        self.stubs.Set(image, '_is_cloneable', lambda x: False)
+        self.assertRaisesRegexp(
+            exception.ImageUnacceptable,
+            'No image locations are accessible',
+            image.direct_fetch,
+            'image_id',
+            {'disk_format': 'raw'},
+            [{'url': 'rbd://a/b/c/d'}]
+    )
 
     def test_good_locations(self):
         image = self.image_class(self.INSTANCE, self.NAME)

--- a/nova/tests/virt/libvirt/test_imagebackend.py
+++ b/nova/tests/virt/libvirt/test_imagebackend.py
@@ -965,6 +965,10 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
 
         self.assertFalse(image._is_cloneable(location))
 
+    def test_parent_compatible(self):
+        self.assertEqual(getargspec(imagebackend.Image.libvirt_info),
+             getargspec(self.image_class.libvirt_info))
+
 
 class BackendTestCase(test.NoDBTestCase):
     INSTANCE = {'name': 'fake-instance',

--- a/nova/tests/virt/libvirt/test_libvirt.py
+++ b/nova/tests/virt/libvirt/test_libvirt.py
@@ -3307,6 +3307,30 @@ class LibvirtConnTestCase(test.TestCase):
         conn.pre_live_migration(self.context, instance, block_device_info=None,
                                 network_info=[], disk_info={})
 
+    def test_pre_live_migration_with_shared_instance_path(self):
+        migrate_data = {'is_shared_block_storage': False,
+                        'block_migration': False}
+
+        conn = libvirt_driver.LibvirtDriver(fake.FakeVirtAPI(), False)
+        instance = db.instance_create(self.context, self.test_instance)
+        # creating mocks
+        with contextlib.nested(
+            mock.patch.object(conn,
+                              '_create_images_and_backing'),
+            mock.patch.object(conn,
+                              'ensure_filtering_rules_for_instance'),
+            mock.patch.object(conn, 'plug_vifs'),
+        ) as (
+            create_image_mock,
+            rules_mock,
+            plug_mock,
+        ):
+            conn.pre_live_migration(self.context, instance,
+                                    block_device_info=None,
+                                    network_info=[], disk_info={},
+                                    migrate_data=migrate_data)
+            self.assertFalse(create_image_mock.called)
+
     def test_get_instance_disk_info_works_correctly(self):
         # Test data
         instance_ref = db.instance_create(self.context, self.test_instance)

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -3428,6 +3428,9 @@ class LibvirtDriver(driver.ComputeDriver):
         if CONF.libvirt_images_type == 'lvm':
             info = libvirt_utils.get_volume_group_info(
                                  CONF.libvirt_images_volume_group)
+        elif CONF.libvirt_images_type == 'rbd':
+            info = libvirt_utils.get_rbd_pool_info(
+                                 CONF.libvirt_images_rbd_pool)
         else:
             info = libvirt_utils.get_fs_info(CONF.instances_path)
 

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -4186,7 +4186,7 @@ class LibvirtDriver(driver.ComputeDriver):
                 raise exception.DestinationDiskExists(path=instance_dir)
             os.mkdir(instance_dir)
 
-        if not is_shared_block_storage:
+        if not (is_shared_block_storage or is_shared_instance_path):
             # Ensure images and backing files are present.
             self._create_images_and_backing(context, instance, instance_dir,
                                             disk_info)

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -1400,6 +1400,44 @@ class LibvirtDriver(driver.ComputeDriver):
             snapshot_backend.snapshot_create()
 
         update_task_state(task_state=task_states.IMAGE_PENDING_UPLOAD)
+
+        try:
+            url = snapshot_backend.direct_snapshot(snapshot_name,
+                                                   image_format,
+                                                   image_id)
+            metadata['location'] = url
+            try:
+                image_service.update(context,
+                                     image_href,
+                                     metadata)
+            except Exception as e:
+                LOG.debug('failed to update glance', exc_info=True)
+                reason = _('failed to update glance: %s') % e
+                raise exception.ImageUnacceptable(image_id=image_id,
+                                                  reason=reason)
+            update_task_state(task_state=task_states.IMAGE_UPLOADING,
+                     expected_state=task_states.IMAGE_PENDING_UPLOAD)
+            LOG.info(_("Snapshot image upload complete"),
+                         instance=instance)
+        except exception.ImageUnacceptable:
+            LOG.debug('direct snapshot failed', exc_info=True)
+            self._generic_snapshot(context, snapshot_name,
+                                   snapshot_backend,
+                                   disk_path,
+                                   live_snapshot,
+                                   virt_dom,
+                                   state,
+                                   image_format,
+                                   instance,
+                                   image_href,
+                                   metadata,
+                                   image_service,
+                                   update_task_state)
+
+    def _generic_snapshot(self, context, snapshot_name, snapshot_backend,
+                          disk_path, live_snapshot,  virt_dom, state,
+                          image_format, instance, image_href, metadata,
+                          image_service, update_task_state):
         snapshot_directory = CONF.libvirt_snapshots_directory
         fileutils.ensure_tree(snapshot_directory)
         with utils.tempdir(dir=snapshot_directory) as tmpdir:

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -201,8 +201,7 @@ class Image(object):
                           (CONF.preallocate_images, self.path))
         return can_fallocate
 
-    @staticmethod
-    def verify_base_size(base, size, base_size=0):
+    def verify_base_size(self, base, size, base_size=0):
         """Check that the base image is not larger than size.
            Since images can't be generally shrunk, enforce this
            constraint taking account of virtual image size.
@@ -221,7 +220,7 @@ class Image(object):
             return
 
         if size and not base_size:
-            base_size = disk.get_disk_size(base)
+            base_size = self.get_disk_size(base)
 
         if size < base_size:
             msg = _('%(base)s virtual size %(base_size)s '
@@ -230,6 +229,9 @@ class Image(object):
                               'base_size': base_size,
                               'size': size})
             raise exception.InstanceTypeDiskTooSmall()
+
+    def get_disk_size(self, name):
+        disk.get_disk_size(name)
 
     def snapshot_create(self):
         raise NotImplementedError()
@@ -695,7 +697,10 @@ class Rbd(Image):
             vol.resize(int(size))
 
     def _size(self):
-        with RBDVolumeProxy(self, self.rbd_name) as vol:
+        return self.get_disk_size(self.rbd_name)
+
+    def get_disk_size(self, name):
+        with RBDVolumeProxy(self, name) as vol:
             return vol.size()
 
     def create_image(self, prepare_template, base, size, *args, **kwargs):

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -309,6 +309,16 @@ class Image(object):
         reason = _('direct_fetch() is not implemented')
         raise exception.ImageUnacceptable(image_id=image_id, reason=reason)
 
+    def direct_snapshot(self, snapshot_name, image_format, image_id):
+        """Prepare a snapshot for direct reference from glance
+
+        :raises: exception.ImageUnacceptable if it cannot be
+                 referenced directly in the specified image format
+        :returns: URL to be given to glance
+        """
+        reason = _('direct_snapshot() is not implemented')
+        raise exception.ImageUnacceptable(image_id=image_id, reason=reason)
+
 
 class Raw(Image):
     def __init__(self, instance=None, disk_name=None, path=None,
@@ -774,14 +784,14 @@ class Rbd(Image):
                       dict(loc=image_location, err=e))
             return False
 
-    def _clone(self, pool, image, snapshot):
+    def _clone(self, pool, image, snapshot, clone_name):
         with RADOSClient(self, str(pool)) as src_client:
             with RADOSClient(self) as dest_client:
                 self.rbd.RBD().clone(src_client.ioctx,
                                      str(image),
                                      str(snapshot),
                                      dest_client.ioctx,
-                                     self.rbd_name,
+                                     clone_name,
                                      features=self.rbd.RBD_FEATURE_LAYERING)
 
     def direct_fetch(self, image_id, image_meta, image_locations, max_size=0):
@@ -798,10 +808,52 @@ class Rbd(Image):
             url = location['url']
             if self._is_cloneable(url):
                 prefix, pool, image, snapshot = self._parse_location(url)
-                return self._clone(pool, image, snapshot)
+                return self._clone(pool, image, snapshot, self.rbd_name)
 
         reason = _('No image locations are accessible')
         raise exception.ImageUnacceptable(image_id=image_id, reason=reason)
+
+    def _create_snapshot(self, name, snap_name):
+        """Creates an rbd snapshot."""
+        with RBDVolumeProxy(self, name) as volume:
+            snap = snap_name.encode('utf-8')
+            volume.create_snap(snap)
+            if self._supports_layering():
+                volume.protect_snap(snap)
+
+    def _delete_snapshot(self, name, snap_name):
+        """Deletes an rbd snapshot."""
+        # NOTE(dosaboy): this was broken by commit cbe1d5f. Ensure names are
+        #                utf-8 otherwise librbd will barf.
+        snap = snap_name.encode('utf-8')
+        with RBDVolumeProxy(self, name) as volume:
+            if self._supports_layering():
+                try:
+                    volume.unprotect_snap(snap)
+                except rbd.ImageBusy:
+                    raise exception.SnapshotIsBusy(snapshot_name=snap)
+            volume.remove_snap(snap)
+
+    def direct_snapshot(self, snapshot_name, image_format, image_id):
+        deletion_marker = '_to_be_deleted_by_glance'
+        if image_format != 'raw':
+            reason = _('only raw format is supported')
+            raise exception.ImageUnacceptable(image_id=image_id, reason=reason)
+        if not self._supports_layering():
+            reason = _('librbd is too old')
+            raise exception.ImageUnacceptable(image_id=image_id, reason=reason)
+        rbd_snap_name = snapshot_name + deletion_marker
+        self._create_snapshot(self.rbd_name, rbd_snap_name)
+        clone_name = self.rbd_name + '_clone_' + snapshot_name
+        clone_snap = 'snap'
+        self._clone(self.pool, self.rbd_name, rbd_snap_name, clone_name)
+        self._create_snapshot(clone_name, clone_snap)
+        fsid = self._get_fsid()
+        return 'rbd://{fsid}/{pool}/{image}/{snap}'.format(
+            fsid=fsid,
+            pool=self.pool,
+            image=clone_name,
+            snap=clone_snap)
 
 
 class Backend(object):

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -534,7 +534,8 @@ class RBDVolumeProxy(object):
         client, ioctx = driver._connect_to_rados(pool)
         try:
             self.volume = driver.rbd.Image(ioctx, str(name),
-                                           snapshot=ascii_str(snapshot),
+                                           snapshot=libvirt_utils.ascii_str(
+                                                        snapshot),
                                            read_only=read_only)
         except driver.rbd.Error:
             LOG.exception(_("error opening rbd image %s"), name)
@@ -570,17 +571,6 @@ class RADOSClient(object):
         self.driver._disconnect_from_rados(self.cluster, self.ioctx)
 
 
-def ascii_str(s):
-    """Convert a string to ascii, or return None if the input is None.
-
-    This is useful when a parameter is None by default, or a string. LibRBD
-    only accepts ascii, hence the need for conversion.
-    """
-    if s is None:
-        return s
-    return str(s)
-
-
 class Rbd(Image):
     def __init__(self, instance=None, disk_name=None, path=None,
                  snapshot_name=None, **kwargs):
@@ -598,8 +588,9 @@ class Rbd(Image):
                                  ' libvirt_images_rbd_pool'
                                  ' flag to use rbd images.'))
         self.pool = str(CONF.libvirt_images_rbd_pool)
-        self.ceph_conf = ascii_str(CONF.libvirt_images_rbd_ceph_conf)
-        self.rbd_user = ascii_str(CONF.rbd_user)
+        self.ceph_conf = libvirt_utils.ascii_str(
+                         CONF.libvirt_images_rbd_ceph_conf)
+        self.rbd_user = libvirt_utils.ascii_str(CONF.rbd_user)
         self.rbd = kwargs.get('rbd', rbd)
         self.rados = kwargs.get('rados', rados)
 

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -301,7 +301,7 @@ class Image(object):
             raise exception.DiskInfoReadWriteFail(reason=unicode(e))
         return driver_format
 
-    def direct_fetch(self, image_id, image_meta, image_locations):
+    def direct_fetch(self, image_id, image_meta, image_locations, max_size=0):
         """Create an image from a direct image location.
 
         :raises: exception.ImageUnacceptable if it cannot be fetched directly
@@ -793,7 +793,7 @@ class Rbd(Image):
                                      self.rbd_name,
                                      features=self.rbd.RBD_FEATURE_LAYERING)
 
-    def direct_fetch(self, image_id, image_meta, image_locations):
+    def direct_fetch(self, image_id, image_meta, image_locations, max_size=0):
         if self.check_image_exists():
             return
         if image_meta.get('disk_format') not in ['raw', 'iso']:

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -726,7 +726,7 @@ class Rbd(Image):
         pass
 
     def snapshot_extract(self, target, out_format):
-        snap = 'rbd:%s/%s' % (self.pool, self.rbd_name)
+        snap = 'rbd:%s/%s:id=%s' % (self.pool, self.rbd_name, self.rbd_user)
         images.convert_image(snap, target, out_format)
 
     def snapshot_delete(self):

--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -72,8 +72,6 @@ CONF = cfg.CONF
 CONF.register_opts(__imagebackend_opts)
 CONF.import_opt('base_dir_name', 'nova.virt.libvirt.imagecache')
 CONF.import_opt('preallocate_images', 'nova.virt.driver')
-CONF.import_opt('rbd_user', 'nova.virt.libvirt.volume')
-CONF.import_opt('rbd_secret_uuid', 'nova.virt.libvirt.volume')
 
 LOG = logging.getLogger(__name__)
 
@@ -203,7 +201,8 @@ class Image(object):
                           (CONF.preallocate_images, self.path))
         return can_fallocate
 
-    def verify_base_size(self, base, size, base_size=0):
+    @staticmethod
+    def verify_base_size(base, size, base_size=0):
         """Check that the base image is not larger than size.
            Since images can't be generally shrunk, enforce this
            constraint taking account of virtual image size.
@@ -222,7 +221,7 @@ class Image(object):
             return
 
         if size and not base_size:
-            base_size = self.get_disk_size(base)
+            base_size = disk.get_disk_size(base)
 
         if size < base_size:
             msg = _('%(base)s virtual size %(base_size)s '
@@ -232,13 +231,13 @@ class Image(object):
                               'size': size})
             raise exception.InstanceTypeDiskTooSmall()
 
-    def get_disk_size(self, name):
-        disk.get_disk_size(name)
-
     def snapshot_create(self):
         raise NotImplementedError()
 
     def snapshot_extract(self, target, out_format):
+        raise NotImplementedError()
+
+    def snapshot_delete(self):
         raise NotImplementedError()
 
     def _get_driver_format(self):
@@ -300,7 +299,7 @@ class Image(object):
             raise exception.DiskInfoReadWriteFail(reason=unicode(e))
         return driver_format
 
-    def direct_fetch(self, image_id, image_meta, image_locations, max_size=0):
+    def direct_fetch(self, image_id, image_meta, image_locations):
         """Create an image from a direct image location.
 
         :raises: exception.ImageUnacceptable if it cannot be fetched directly
@@ -310,12 +309,14 @@ class Image(object):
 
 
 class Raw(Image):
-    def __init__(self, instance=None, disk_name=None, path=None):
+    def __init__(self, instance=None, disk_name=None, path=None,
+                 snapshot_name=None):
         super(Raw, self).__init__("file", "raw", is_block_dev=False)
 
         self.path = (path or
                      os.path.join(libvirt_utils.get_instance_path(instance),
                                   disk_name))
+        self.snapshot_name = snapshot_name
         self.preallocate = CONF.preallocate_images != 'none'
         self.disk_info_path = os.path.join(os.path.dirname(self.path),
                                            'disk.info')
@@ -350,17 +351,25 @@ class Raw(Image):
                     copy_raw_image(base, self.path, size)
         self.correct_format()
 
+    def snapshot_create(self):
+        pass
+
     def snapshot_extract(self, target, out_format):
         images.convert_image(self.path, target, out_format)
 
+    def snapshot_delete(self):
+        pass
+
 
 class Qcow2(Image):
-    def __init__(self, instance=None, disk_name=None, path=None):
+    def __init__(self, instance=None, disk_name=None, path=None,
+                 snapshot_name=None):
         super(Qcow2, self).__init__("file", "qcow2", is_block_dev=False)
 
         self.path = (path or
                      os.path.join(libvirt_utils.get_instance_path(instance),
                                   disk_name))
+        self.snapshot_name = snapshot_name
         self.preallocate = CONF.preallocate_images != 'none'
         self.disk_info_path = os.path.join(os.path.dirname(self.path),
                                            'disk.info')
@@ -410,10 +419,16 @@ class Qcow2(Image):
             with fileutils.remove_path_on_error(self.path):
                 copy_qcow2_image(base, self.path, size)
 
+    def snapshot_create(self):
+        libvirt_utils.create_snapshot(self.path, self.snapshot_name)
+
     def snapshot_extract(self, target, out_format):
         libvirt_utils.extract_snapshot(self.path, 'qcow2',
-                                       target,
+                                       self.snapshot_name, target,
                                        out_format)
+
+    def snapshot_delete(self):
+        libvirt_utils.delete_snapshot(self.path, self.snapshot_name)
 
 
 class Lvm(Image):
@@ -421,7 +436,8 @@ class Lvm(Image):
     def escape(filename):
         return filename.replace('_', '__')
 
-    def __init__(self, instance=None, disk_name=None, path=None):
+    def __init__(self, instance=None, disk_name=None, path=None,
+                 snapshot_name=None):
         super(Lvm, self).__init__("block", "raw", is_block_dev=True)
 
         if path:
@@ -443,6 +459,11 @@ class Lvm(Image):
         # for the more general preallocate_images
         self.sparse = CONF.libvirt_sparse_logical_volumes
         self.preallocate = not self.sparse
+
+        if snapshot_name:
+            self.snapshot_name = snapshot_name
+            self.snapshot_path = os.path.join('/dev', self.vg,
+                                              self.snapshot_name)
 
     def _can_fallocate(self):
         return False
@@ -481,9 +502,20 @@ class Lvm(Image):
             with excutils.save_and_reraise_exception():
                 libvirt_utils.remove_logical_volumes(path)
 
+    def snapshot_create(self):
+        size = CONF.libvirt_lvm_snapshot_size
+        cmd = ('lvcreate', '-L', size, '-s', '--name', self.snapshot_name,
+               self.path)
+        libvirt_utils.execute(*cmd, run_as_root=True, attempts=3)
+
     def snapshot_extract(self, target, out_format):
-        images.convert_image(self.path, target, out_format,
+        images.convert_image(self.snapshot_path, target, out_format,
                              run_as_root=True)
+
+    def snapshot_delete(self):
+        # NOTE (rmk): Snapshot volumes are automatically zeroed by LVM
+        cmd = ('lvremove', '-f', self.snapshot_path)
+        libvirt_utils.execute(*cmd, run_as_root=True, attempts=3)
 
 
 class RBDVolumeProxy(object):
@@ -500,8 +532,7 @@ class RBDVolumeProxy(object):
         client, ioctx = driver._connect_to_rados(pool)
         try:
             self.volume = driver.rbd.Image(ioctx, str(name),
-                                           snapshot=libvirt_utils.ascii_str(
-                                                        snapshot),
+                                           snapshot=ascii_str(snapshot),
                                            read_only=read_only)
         except driver.rbd.Error:
             LOG.exception(_("error opening rbd image %s"), name)
@@ -537,10 +568,21 @@ class RADOSClient(object):
         self.driver._disconnect_from_rados(self.cluster, self.ioctx)
 
 
+def ascii_str(s):
+    """Convert a string to ascii, or return None if the input is None.
+
+    This is useful when a parameter is None by default, or a string. LibRBD
+    only accepts ascii, hence the need for conversion.
+    """
+    if s is None:
+        return s
+    return str(s)
+
+
 class Rbd(Image):
     def __init__(self, instance=None, disk_name=None, path=None,
                  snapshot_name=None, **kwargs):
-        super(Rbd, self).__init__("block", 'raw', is_block_dev=True)
+        super(Rbd, self).__init__("block", "rbd", is_block_dev=True)
         if path:
             try:
                 self.rbd_name = str(path.split('/')[1])
@@ -554,17 +596,10 @@ class Rbd(Image):
                                  ' libvirt_images_rbd_pool'
                                  ' flag to use rbd images.'))
         self.pool = str(CONF.libvirt_images_rbd_pool)
-        self.ceph_conf = libvirt_utils.ascii_str(
-                         CONF.libvirt_images_rbd_ceph_conf)
-        self.rbd_user = libvirt_utils.ascii_str(CONF.rbd_user)
+        self.ceph_conf = ascii_str(CONF.libvirt_images_rbd_ceph_conf)
+        self.rbd_user = ascii_str(CONF.rbd_user)
         self.rbd = kwargs.get('rbd', rbd)
         self.rados = kwargs.get('rados', rados)
-
-        self.path = 'rbd:%s/%s' % (self.pool, self.rbd_name)
-        if self.rbd_user:
-            self.path += ':id=' + self.rbd_user
-        if self.ceph_conf:
-            self.path += ':conf=' + self.ceph_conf
 
     def _connect_to_rados(self, pool=None):
         client = self.rados.Rados(rados_id=self.rbd_user,
@@ -611,7 +646,7 @@ class Rbd(Image):
         return hosts, ports
 
     def libvirt_info(self, disk_bus, disk_dev, device_type, cache_mode,
-            extra_specs, hypervisor_version):
+                     extra_specs, hypervisor_version):
         """Get `LibvirtConfigGuestDisk` filled for this image.
 
         :disk_dev: Disk bus device name
@@ -660,10 +695,7 @@ class Rbd(Image):
             vol.resize(int(size))
 
     def _size(self):
-        return self.get_disk_size(self.rbd_name)
-
-    def get_disk_size(self, name):
-        with RBDVolumeProxy(self, name) as vol:
+        with RBDVolumeProxy(self, self.rbd_name) as vol:
             return vol.size()
 
     def create_image(self, prepare_template, base, size, *args, **kwargs):
@@ -694,8 +726,12 @@ class Rbd(Image):
         if size and self._size() < size:
             self._resize(size)
 
+    def snapshot_create(self):
+        pass
+
     def snapshot_extract(self, target, out_format):
-        images.convert_image(self.path, target, out_format)
+        snap = 'rbd:%s/%s' % (self.pool, self.rbd_name)
+        images.convert_image(snap, target, out_format)
 
     def snapshot_delete(self):
         pass
@@ -752,7 +788,7 @@ class Rbd(Image):
                                      self.rbd_name,
                                      features=self.rbd.RBD_FEATURE_LAYERING)
 
-    def direct_fetch(self, image_id, image_meta, image_locations, max_size=0):
+    def direct_fetch(self, image_id, image_meta, image_locations):
         if self.check_image_exists():
             return
         if image_meta.get('disk_format') not in ['raw', 'iso']:
@@ -801,11 +837,12 @@ class Backend(object):
         backend = self.backend(image_type)
         return backend(instance=instance, disk_name=disk_name)
 
-    def snapshot(self, disk_path, image_type=None):
+    def snapshot(self, disk_path, snapshot_name, image_type=None):
         """Returns snapshot for given image
 
         :path: path to image
+        :snapshot_name: snapshot name
         :image_type: type of image
         """
         backend = self.backend(image_type)
-        return backend(path=disk_path)
+        return backend(path=disk_path, snapshot_name=snapshot_name)

--- a/nova/virt/libvirt/utils.py
+++ b/nova/virt/libvirt/utils.py
@@ -321,7 +321,7 @@ def remove_rbd_volumes(pool, *names):
 
 def get_rbd_pool_info(pool):
     client, ioctx = _connect_to_rados(pool)
-    stats = client.get_cluster_stats()
+    stats = client.cluster.get_cluster_stats()
     return {'total': stats['kb'] * 1024,
             'free': stats['kb_avail'] * 1024,
             'used': stats['kb_used'] * 1024}
@@ -548,11 +548,33 @@ def chown(path, owner):
     execute('chown', owner, path, run_as_root=True)
 
 
-def extract_snapshot(disk_path, source_fmt, out_path, dest_fmt):
-    """Extract a snapshot from a disk image.
-    Note that nobody should write to the disk image during this operation.
+def create_snapshot(disk_path, snapshot_name):
+    """Create a snapshot in a disk image
 
     :param disk_path: Path to disk image
+    :param snapshot_name: Name of snapshot in disk image
+    """
+    qemu_img_cmd = ('qemu-img', 'snapshot', '-c', snapshot_name, disk_path)
+    # NOTE(vish): libvirt changes ownership of images
+    execute(*qemu_img_cmd, run_as_root=True)
+
+
+def delete_snapshot(disk_path, snapshot_name):
+    """Create a snapshot in a disk image
+
+    :param disk_path: Path to disk image
+    :param snapshot_name: Name of snapshot in disk image
+    """
+    qemu_img_cmd = ('qemu-img', 'snapshot', '-d', snapshot_name, disk_path)
+    # NOTE(vish): libvirt changes ownership of images
+    execute(*qemu_img_cmd, run_as_root=True)
+
+
+def extract_snapshot(disk_path, source_fmt, snapshot_name, out_path, dest_fmt):
+    """Extract a named snapshot from a disk image
+
+    :param disk_path: Path to disk image
+    :param snapshot_name: Name of snapshot in disk image
     :param out_path: Desired path of extracted snapshot
     """
     # NOTE(markmc): ISO is just raw to qemu-img
@@ -564,6 +586,11 @@ def extract_snapshot(disk_path, source_fmt, out_path, dest_fmt):
     # Conditionally enable compression of snapshots.
     if CONF.libvirt_snapshot_compression and dest_fmt == "qcow2":
         qemu_img_cmd += ('-c',)
+
+    # When snapshot name is omitted we do a basic convert, which
+    # is used by live snapshots.
+    if snapshot_name is not None:
+        qemu_img_cmd += ('-s', snapshot_name)
 
     qemu_img_cmd += (disk_path, out_path)
     execute(*qemu_img_cmd)


### PR DESCRIPTION
Using this code in alln integration, I was able to get efficient RBD cloning of ephemeral instances without the need to download the image from ceph, and then upload it to glance

Rally-bug: TA8264
Rally-bug: DE1186
Not-in-upstream: true
