### PR TITLE
Rbd cherrypicking

### DIFF
--- a/nova/tests/virt/libvirt/test_imagebackend.py
+++ b/nova/tests/virt/libvirt/test_imagebackend.py
@@ -402,14 +402,14 @@ class Qcow2TestCase(_ImageTestCase, test.NoDBTestCase):
     def test_create_image_too_small(self):
         fn = self.prepare_mocks()
         self.mox.StubOutWithMock(os.path, 'exists')
-        self.mox.StubOutWithMock(imagebackend.Qcow2, 'get_disk_size')
+        self.mox.StubOutWithMock(imagebackend.disk, 'get_disk_size')
         if self.OLD_STYLE_INSTANCE_PATH:
             os.path.exists(self.OLD_STYLE_INSTANCE_PATH).AndReturn(False)
         os.path.exists(self.DISK_INFO_PATH).AndReturn(False)
         os.path.exists(self.INSTANCES_PATH).AndReturn(True)
         os.path.exists(self.TEMPLATE_PATH).AndReturn(True)
-        imagebackend.Qcow2.get_disk_size(self.TEMPLATE_PATH
-                                         ).AndReturn(self.SIZE)
+        imagebackend.disk.get_disk_size(self.TEMPLATE_PATH
+                                       ).AndReturn(self.SIZE)
         self.mox.ReplayAll()
 
         image = self.image_class(self.INSTANCE, self.NAME)
@@ -962,20 +962,9 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
 
         self.assertFalse(image._is_cloneable(location))
 
-    def test_image_path(self):
-
-        conf = "FakeConf"
-        pool = "FakePool"
-        user = "FakeUser"
-
-        self.flags(libvirt_images_rbd_pool=pool)
-        self.flags(libvirt_images_rbd_ceph_conf=conf)
-        self.flags(rbd_user=user)
-        image = self.image_class(self.INSTANCE, self.NAME)
-        rbd_path = "rbd:%s/%s:id=%s:conf=%s" % (pool, image.rbd_name,
-                                                user, conf)
-
-        self.assertEqual(image.path, rbd_path)
+    def test_parent_compatible(self):
+        self.assertEqual(getargspec(imagebackend.Image.libvirt_info),
+             getargspec(self.image_class.libvirt_info))
 
 
 class BackendTestCase(test.NoDBTestCase):

--- a/nova/tests/virt/libvirt/test_imagebackend.py
+++ b/nova/tests/virt/libvirt/test_imagebackend.py
@@ -811,21 +811,6 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
 
         self.mox.VerifyAll()
 
-    def test_cache_base_dir_exists(self):
-        self.mox.StubOutWithMock(os.path, 'exists')
-        os.path.exists(self.TEMPLATE_DIR).AndReturn(True)
-        os.path.exists(self.TEMPLATE_PATH).AndReturn(False)
-        fn = self.mox.CreateMockAnything()
-        fn(target=self.TEMPLATE_PATH)
-        self.mox.StubOutWithMock(imagebackend.fileutils, 'ensure_tree')
-        self.mox.ReplayAll()
-
-        image = self.image_class(self.INSTANCE, self.NAME)
-        self.mock_create_image(image)
-        image.cache(fn, self.TEMPLATE)
-
-        self.mox.VerifyAll()
-
     def test_create_image(self):
         fn = self.prepare_mocks()
         fn(max_size=None, rbd=self.rbd, target=self.TEMPLATE_PATH)

--- a/nova/tests/virt/libvirt/test_libvirt.py
+++ b/nova/tests/virt/libvirt/test_libvirt.py
@@ -3307,6 +3307,30 @@ class LibvirtConnTestCase(test.TestCase):
         conn.pre_live_migration(self.context, instance, block_device_info=None,
                                 network_info=[], disk_info={})
 
+    def test_pre_live_migration_with_shared_instance_path(self):
+        migrate_data = {'is_shared_block_storage': False,
+                        'block_migration': False}
+
+        conn = libvirt_driver.LibvirtDriver(fake.FakeVirtAPI(), False)
+        instance = db.instance_create(self.context, self.test_instance)
+        # creating mocks
+        with contextlib.nested(
+            mock.patch.object(conn,
+                              '_create_images_and_backing'),
+            mock.patch.object(conn,
+                              'ensure_filtering_rules_for_instance'),
+            mock.patch.object(conn, 'plug_vifs'),
+        ) as (
+            create_image_mock,
+            rules_mock,
+            plug_mock,
+        ):
+            conn.pre_live_migration(self.context, instance,
+                                    block_device_info=None,
+                                    network_info=[], disk_info={},
+                                    migrate_data=migrate_data)
+            self.assertFalse(create_image_mock.called)
+
     def test_get_instance_disk_info_works_correctly(self):
         # Test data
         instance_ref = db.instance_create(self.context, self.test_instance)

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -4225,7 +4225,7 @@ class LibvirtDriver(driver.ComputeDriver):
                 raise exception.DestinationDiskExists(path=instance_dir)
             os.mkdir(instance_dir)
 
-        if not is_shared_block_storage:
+        if not (is_shared_block_storage or is_shared_instance_path):
             # Ensure images and backing files are present.
             self._create_images_and_backing(context, instance, instance_dir,
                                             disk_info)

--- a/nova/virt/libvirt/utils.py
+++ b/nova/virt/libvirt/utils.py
@@ -321,7 +321,7 @@ def remove_rbd_volumes(pool, *names):
 
 def get_rbd_pool_info(pool):
     client, ioctx = _connect_to_rados(pool)
-    stats = client.get_cluster_stats()
+    stats = client.cluster.get_cluster_stats()
     return {'total': stats['kb'] * 1024,
             'free': stats['kb_avail'] * 1024,
             'used': stats['kb_used'] * 1024}
@@ -548,11 +548,33 @@ def chown(path, owner):
     execute('chown', owner, path, run_as_root=True)
 
 
-def extract_snapshot(disk_path, source_fmt, out_path, dest_fmt):
-    """Extract a snapshot from a disk image.
-    Note that nobody should write to the disk image during this operation.
+def create_snapshot(disk_path, snapshot_name):
+    """Create a snapshot in a disk image
 
     :param disk_path: Path to disk image
+    :param snapshot_name: Name of snapshot in disk image
+    """
+    qemu_img_cmd = ('qemu-img', 'snapshot', '-c', snapshot_name, disk_path)
+    # NOTE(vish): libvirt changes ownership of images
+    execute(*qemu_img_cmd, run_as_root=True)
+
+
+def delete_snapshot(disk_path, snapshot_name):
+    """Create a snapshot in a disk image
+
+    :param disk_path: Path to disk image
+    :param snapshot_name: Name of snapshot in disk image
+    """
+    qemu_img_cmd = ('qemu-img', 'snapshot', '-d', snapshot_name, disk_path)
+    # NOTE(vish): libvirt changes ownership of images
+    execute(*qemu_img_cmd, run_as_root=True)
+
+
+def extract_snapshot(disk_path, source_fmt, snapshot_name, out_path, dest_fmt):
+    """Extract a named snapshot from a disk image
+
+    :param disk_path: Path to disk image
+    :param snapshot_name: Name of snapshot in disk image
     :param out_path: Desired path of extracted snapshot
     """
     # NOTE(markmc): ISO is just raw to qemu-img
@@ -564,6 +586,11 @@ def extract_snapshot(disk_path, source_fmt, out_path, dest_fmt):
     # Conditionally enable compression of snapshots.
     if CONF.libvirt_snapshot_compression and dest_fmt == "qcow2":
         qemu_img_cmd += ('-c',)
+
+    # When snapshot name is omitted we do a basic convert, which
+    # is used by live snapshots.
+    if snapshot_name is not None:
+        qemu_img_cmd += ('-s', snapshot_name)
 
     qemu_img_cmd += (disk_path, out_path)
     execute(*qemu_img_cmd)


### PR DESCRIPTION
This is a cherry-picking of the missing commits from jdurgin's fork. This completes the previous set of cherry picks from #10 - This code has been tested in alln and functions as expected. Also, each commit has the appropriate tags.

Closes-rally-bug: DE1186
Implements: rally-task: TA8264
Not-in-upstream: true
