### PR TITLE
Fixed failing tests

### DIFF
--- a/nova/tests/virt/libvirt/test_imagebackend.py
+++ b/nova/tests/virt/libvirt/test_imagebackend.py
@@ -402,14 +402,14 @@ class Qcow2TestCase(_ImageTestCase, test.NoDBTestCase):
     def test_create_image_too_small(self):
         fn = self.prepare_mocks()
         self.mox.StubOutWithMock(os.path, 'exists')
-        self.mox.StubOutWithMock(imagebackend.disk, 'get_disk_size')
+        self.mox.StubOutWithMock(imagebackend.Qcow2, 'get_disk_size')
         if self.OLD_STYLE_INSTANCE_PATH:
             os.path.exists(self.OLD_STYLE_INSTANCE_PATH).AndReturn(False)
         os.path.exists(self.DISK_INFO_PATH).AndReturn(False)
         os.path.exists(self.INSTANCES_PATH).AndReturn(True)
         os.path.exists(self.TEMPLATE_PATH).AndReturn(True)
-        imagebackend.disk.get_disk_size(self.TEMPLATE_PATH
-                                       ).AndReturn(self.SIZE)
+        imagebackend.Qcow2.get_disk_size(self.TEMPLATE_PATH
+                                         ).AndReturn(self.SIZE)
         self.mox.ReplayAll()
 
         image = self.image_class(self.INSTANCE, self.NAME)
@@ -860,8 +860,9 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
         self.rbd.RBD_FEATURE_LAYERING = 1
 
         image = self.image_class(self.INSTANCE, self.NAME)
+        clone_name = self.INSTANCE['uuid'] + '_' + self.NAME
         self.mox.StubOutWithMock(image, '_clone')
-        image._clone('b', 'c', 'd')
+        image._clone('b', 'c', 'd', clone_name)
         self.mox.ReplayAll()
 
         def fake_parse_location(url):

--- a/nova/tests/virt/libvirt/test_libvirt.py
+++ b/nova/tests/virt/libvirt/test_libvirt.py
@@ -6780,12 +6780,12 @@ disk size: 4.4M''', ''))
     def _do_test_extract_snapshot(self, dest_format='raw', out_format='raw'):
         self.mox.StubOutWithMock(utils, 'execute')
         utils.execute('qemu-img', 'convert', '-f', 'qcow2', '-O', out_format,
-                      '/path/to/disk/image', '/extracted/snap')
+                      '-s', 'snap1', '/path/to/disk/image', '/extracted/snap')
 
         # Start test
         self.mox.ReplayAll()
         libvirt_utils.extract_snapshot('/path/to/disk/image', 'qcow2',
-                                       '/extracted/snap', dest_format)
+                                       'snap1', '/extracted/snap', dest_format)
 
     def test_extract_snapshot_raw(self):
         self._do_test_extract_snapshot()


### PR DESCRIPTION
There were various issues with the tests, I later found out
that the original author hadn't written tests for havana
This now finishes ./run_tests clean

Closes-rally-bug: DE1186
Implements: rally-task: TA8264
Not-in-upstream: true
