### PR TITLE
Force Hard reboot re-create instance folder

### DIFF
--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -1456,7 +1456,7 @@ class LibvirtDriver(driver.ComputeDriver):
                                    update_task_state)
 
     def _generic_snapshot(self, context, snapshot_name, snapshot_backend,
-                          disk_path, live_snapshot,  virt_dom, state,
+                          disk_path, live_snapshot, virt_dom, state,
                           image_format, instance, image_href, metadata,
                           image_service, update_task_state):
         snapshot_directory = CONF.libvirt_snapshots_directory
@@ -1981,6 +1981,8 @@ class LibvirtDriver(driver.ComputeDriver):
                                                           service,
                                                           image_id,
                                                           instance)
+        instance_dir = libvirt_utils.get_instance_path(instance)
+        fileutils.ensure_tree(instance_dir)
 
         disk_info = blockinfo.get_disk_info(CONF.libvirt_type,
                                             instance,
@@ -1999,7 +2001,6 @@ class LibvirtDriver(driver.ComputeDriver):
         # NOTE (rmk): Re-populate any missing backing files.
         disk_info_json = self.get_instance_disk_info(instance['name'], xml,
                                                      block_device_info)
-        instance_dir = libvirt_utils.get_instance_path(instance)
         self._create_images_and_backing(context, instance, instance_dir,
                                         disk_info_json)
 


### PR DESCRIPTION
When use share storage like ceph, instance's disk data is in ceph,
instance's disk doesn't rely on local instance folder anymore. So
when rebooting a instance, we should create the instance folder if
it is missed.

Change-Id: I1826d850cd802143e70e0e573ff061e12c6e5a4a
Upstream-Review: https://review.openstack.org/#/c/110524/2
Backported-from: juno
Closes-rally-bug: DE1351
