### PR TITLE
Make LiveMigrateTask use build_request_spec()

### DIFF
--- a/nova/scheduler/utils.py
+++ b/nova/scheduler/utils.py
@@ -39,11 +39,10 @@ def build_request_spec(ctxt, image, instances, instance_type=None):
         instance_type = flavors.extract_flavor(instance)
     # NOTE(comstud): This is a bit ugly, but will get cleaned up when
     # we're passing an InstanceType internal object.
-    extra_specs = db.flavor_extra_specs_get(ctxt,
-                                                   instance_type['flavorid'])
+    extra_specs = db.flavor_extra_specs_get(ctxt, instance_type['flavorid'])
     instance_type['extra_specs'] = extra_specs
     request_spec = {
-            'image': image,
+            'image': image or {},
             'instance_properties': instance,
             'instance_type': instance_type,
             'num_instances': len(instances),

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -1473,7 +1473,7 @@ class LibvirtDriver(driver.ComputeDriver):
                                    update_task_state)
 
     def _generic_snapshot(self, context, snapshot_name, snapshot_backend,
-                          disk_path, live_snapshot,  virt_dom, state,
+                          disk_path, live_snapshot, virt_dom, state,
                           image_format, instance, image_href, metadata,
                           image_service, update_task_state):
         snapshot_directory = CONF.libvirt_snapshots_directory


### PR DESCRIPTION
Some filters like TrustedFilter makes use of extra_specs. Currently,
when live-migration uses the scheduler to select a host, it constructs
a request_spec that has no extra_specs in it.

By making use of the existing helper method build_request_spec(), the
request to the scheduler will include extra_specs.

Change-Id: I5bc6c6418653c256a42da7b0a343086ec9863da1
Closes-Bug: #1224014
Backported-from: icehouse
Upstream-Review: https://review.openstack.org/#/c/46735/
Closes-rally-bug: DE1096
