### PR TITLE
Fix live snapshots

### DIFF
--- a/nova/tests/virt/libvirt/test_libvirt.py
+++ b/nova/tests/virt/libvirt/test_libvirt.py
@@ -6780,12 +6780,12 @@ disk size: 4.4M''', ''))
     def _do_test_extract_snapshot(self, dest_format='raw', out_format='raw'):
         self.mox.StubOutWithMock(utils, 'execute')
         utils.execute('qemu-img', 'convert', '-f', 'qcow2', '-O', out_format,
-                      '-s', 'snap1', '/path/to/disk/image', '/extracted/snap')
+                      '/path/to/disk/image', '/extracted/snap')
 
         # Start test
         self.mox.ReplayAll()
         libvirt_utils.extract_snapshot('/path/to/disk/image', 'qcow2',
-                                       'snap1', '/extracted/snap', dest_format)
+                                       '/extracted/snap', dest_format)
 
     def test_extract_snapshot_raw(self):
         self._do_test_extract_snapshot()

--- a/nova/virt/libvirt/utils.py
+++ b/nova/virt/libvirt/utils.py
@@ -576,11 +576,11 @@ def delete_snapshot(disk_path, snapshot_name):
     execute(*qemu_img_cmd, run_as_root=True)
 
 
-def extract_snapshot(disk_path, source_fmt, snapshot_name, out_path, dest_fmt):
-    """Extract a named snapshot from a disk image
+def extract_snapshot(disk_path, source_fmt, out_path, dest_fmt):
+    """Extract a named snapshot from a disk image.
+    Note that nobody should write to the disk image during this operation.
 
     :param disk_path: Path to disk image
-    :param snapshot_name: Name of snapshot in disk image
     :param out_path: Desired path of extracted snapshot
     """
     # NOTE(markmc): ISO is just raw to qemu-img
@@ -592,11 +592,6 @@ def extract_snapshot(disk_path, source_fmt, snapshot_name, out_path, dest_fmt):
     # Conditionally enable compression of snapshots.
     if CONF.libvirt_snapshot_compression and dest_fmt == "qcow2":
         qemu_img_cmd += ('-c',)
-
-    # When snapshot name is omitted we do a basic convert, which
-    # is used by live snapshots.
-    if snapshot_name is not None:
-        qemu_img_cmd += ('-s', snapshot_name)
 
     qemu_img_cmd += (disk_path, out_path)
     execute(*qemu_img_cmd)


### PR DESCRIPTION
The live snapshots method uses 'extract_snapshots' which we had
an older version of. The latest H4 tarball shows that we do not
pass the name, but the dirty merge we did for the rbd clone did.
As such, when we were doing live snaps, we'd raise the error
TypeError: extract_snapshot() takes exactly 5 arguments (4 given)
as it was expecting the name to be passed.

Not-in-upstream: False
Closes-rally-bug: DE1509
Upstream-Review: https://review.openstack.org/#/c/78529/
