### PR TITLE
Use libvirt filters for network security

### DIFF
--- a/nova/network/neutronv2/api.py
+++ b/nova/network/neutronv2/api.py
@@ -976,11 +976,12 @@ class API(base.Base):
 
     def _nw_info_build_network(self, port, networks, subnets):
         network_name = None
+        shared = None
         for net in networks:
             if port['network_id'] == net['id']:
                 network_name = net['name']
                 tenant_id = net['tenant_id']
-                shared = net['shared']
+                shared = net.get('shared')
                 break
         else:
             tenant_id = port['tenant_id']


### PR DESCRIPTION
Amend an earlier checkin.
Use net.get('shared') instead of net['shared'].
The later will raise KeyError if 'shared' is not found.

Closes-rally-bug: DE789 DE701 DE714 DE505
Implements: rally-task TA5323
Not-in-upstream: true
