### PR TITLE
Force rbd as share storge

### DIFF
--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -3881,7 +3881,8 @@ class LibvirtDriver(driver.ComputeDriver):
 
     def check_instance_shared_storage_local(self, context, instance):
         dirpath = libvirt_utils.get_instance_path(instance)
-
+        if CONF.libvirt_images_type == 'rbd':
+            return None
         if not os.path.exists(dirpath):
             return None
 


### PR DESCRIPTION
The way nova testing if the storage is shared storage is not applied
well in rbd backend, this patch will just mark it as share storage if
libvirt_images_type is rbd.

Closes-rally-bug: DE2234
Not-in-upstream: True

Change-Id: Ib5a6e4a435c212773c7f48927a4b707f1ad28336
